### PR TITLE
feat(web): add navbar GitHub link and move the demo CTA to the founders

### DIFF
--- a/apps/web/src/app/[lang]/components/home-page-section/compliance/compliance.tsx
+++ b/apps/web/src/app/[lang]/components/home-page-section/compliance/compliance.tsx
@@ -1,7 +1,3 @@
-import { actionClass, primaryActionClass } from "@scibly/ui/design-language";
-import { cn } from "@scibly/ui/utils";
-import { ArrowRight } from "lucide-react";
-
 import {
   MarketingSection,
   MarketingSectionHeader,
@@ -29,19 +25,6 @@ export function ComplianceSection({ t }: ComplianceSectionProps) {
         eyebrow={t.eyebrow}
         title={`${t.title} ${t.titleEmphasis}`}
         description={t.subtitle}
-        action={
-          <a
-            href="#cta-section"
-            className={cn(actionClass, primaryActionClass, "group")}
-          >
-            {t.cta}
-            <ArrowRight
-              size={15}
-              className="transition-transform group-hover:translate-x-0.5"
-              aria-hidden
-            />
-          </a>
-        }
       />
 
       <ul

--- a/apps/web/src/app/[lang]/components/home-page-section/compliance/i18n/compliance.i18n.de.json
+++ b/apps/web/src/app/[lang]/components/home-page-section/compliance/i18n/compliance.i18n.de.json
@@ -4,7 +4,6 @@
     "title": "Dein Wissen",
     "titleEmphasis": "bleibt deins.",
     "subtitle": "Klare technische und vertragliche Grundlagen für sensible Lerninhalte.",
-    "cta": "Demo anfordern",
     "registry": {
       "summary": "Vier konkrete Sicherheits- und Compliance Zusagen: DSGVO Konformität, EU gehostete Modelle, kein Training mit Kundendaten und AES Verschlüsselung."
     },

--- a/apps/web/src/app/[lang]/components/home-page-section/compliance/i18n/compliance.i18n.en.json
+++ b/apps/web/src/app/[lang]/components/home-page-section/compliance/i18n/compliance.i18n.en.json
@@ -4,7 +4,6 @@
     "title": "Your knowledge",
     "titleEmphasis": "stays yours.",
     "subtitle": "Clear technical and contractual foundations for sensitive learning content.",
-    "cta": "Request demo",
     "registry": {
       "summary": "Four concrete security and compliance commitments: GDPR compliance, EU hosted models, no training on customer data, and AES encryption."
     },

--- a/apps/web/src/app/[lang]/components/home-page-section/compliance/i18n/compliance.types.ts
+++ b/apps/web/src/app/[lang]/components/home-page-section/compliance/i18n/compliance.types.ts
@@ -3,7 +3,6 @@ export type ComplianceDictionary = {
   title: string;
   titleEmphasis: string;
   subtitle: string;
-  cta: string;
   registry: {
     summary: string;
   };

--- a/apps/web/src/app/[lang]/components/home-page-section/founder/founder.tsx
+++ b/apps/web/src/app/[lang]/components/home-page-section/founder/founder.tsx
@@ -1,4 +1,6 @@
-import { Quote } from "lucide-react";
+import { actionClass, primaryActionClass } from "@scibly/ui/design-language";
+import { cn } from "@scibly/ui/utils";
+import { ArrowRight, Quote } from "lucide-react";
 import Image from "next/image";
 
 import { MarketingSection } from "@/app/[lang]/components/marketing-section-content";
@@ -73,6 +75,18 @@ export function FounderSection({ t }: FounderSectionProps) {
           <p className="text-ink-muted m-0 text-[16.5px] leading-[1.65] text-pretty">
             {t.body}
           </p>
+
+          <a
+            href="#cta-section"
+            className={cn(actionClass, primaryActionClass, "group self-start")}
+          >
+            {t.cta}
+            <ArrowRight
+              size={15}
+              className="transition-transform group-hover:translate-x-0.5"
+              aria-hidden
+            />
+          </a>
         </div>
       </div>
     </MarketingSection>

--- a/apps/web/src/app/[lang]/components/home-page-section/founder/i18n/founder.i18n.de.json
+++ b/apps/web/src/app/[lang]/components/home-page-section/founder/i18n/founder.i18n.de.json
@@ -4,6 +4,7 @@
     "body": "Unternehmenswissen liegt meist verstreut in Dokumenten und Tools, unsichtbar für die, die es bräuchten. Wir machen es für das ganze Team zugänglich, und das auf eine Art, die tatsächlich Spaß macht, statt sich wie eine weitere Pflichtschulung anzufühlen.",
     "attribution": "Felix & Niclas",
     "role": "Gründer von scibly",
+    "cta": "Mit den Gründern sprechen",
     "imageSrcFelix": "https://scibly-assets.s3.eu-central-1.amazonaws.com/Blog-Authors/felix_linkedin.jpeg",
     "imageSrcNiclas": "https://scibly-assets.s3.eu-central-1.amazonaws.com/Blog-Authors/niclas-close-up.webp",
     "imageAltFelix": "Felix, Co Gründer von scibly",

--- a/apps/web/src/app/[lang]/components/home-page-section/founder/i18n/founder.i18n.en.json
+++ b/apps/web/src/app/[lang]/components/home-page-section/founder/i18n/founder.i18n.en.json
@@ -4,6 +4,7 @@
     "body": "Company knowledge usually sits scattered across documents and tools, invisible to the people who need it. We make it accessible to the whole team, in a way that actually feels engaging, instead of like another mandatory training.",
     "attribution": "Felix & Niclas",
     "role": "Founders of scibly",
+    "cta": "Talk to the founders",
     "imageSrcFelix": "https://scibly-assets.s3.eu-central-1.amazonaws.com/Blog-Authors/felix_linkedin.jpeg",
     "imageSrcNiclas": "https://scibly-assets.s3.eu-central-1.amazonaws.com/Blog-Authors/niclas-close-up.webp",
     "imageAltFelix": "Felix, co founder of scibly",

--- a/apps/web/src/app/[lang]/components/home-page-section/founder/i18n/founder.types.ts
+++ b/apps/web/src/app/[lang]/components/home-page-section/founder/i18n/founder.types.ts
@@ -3,6 +3,7 @@ export type FounderDictionary = {
   body: string;
   attribution: string;
   role: string;
+  cta: string;
   imageSrcFelix: string;
   imageSrcNiclas: string;
   imageAltFelix: string;

--- a/apps/web/src/app/[lang]/components/navbar.tsx
+++ b/apps/web/src/app/[lang]/components/navbar.tsx
@@ -6,7 +6,7 @@ import Icon from "@scibly/ui/components/icon";
 import LanguageSwitcher from "@scibly/ui/components/language-switcher";
 import { actionClass, primaryActionClass } from "@scibly/ui/design-language";
 import { cn } from "@scibly/ui/utils";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Github } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Fragment, useEffect, useState } from "react";
@@ -267,7 +267,17 @@ export function Navbar({ t }: NavbarProps) {
             </a>
           </div>
 
-          <div className="hidden min-w-0 flex-1 items-center justify-end md:flex">
+          <div className="hidden min-w-0 flex-1 items-center justify-end gap-0.5 md:flex">
+            <a
+              href={routes.external.github.repo}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={t.github}
+              title={t.github}
+              className="hover:bg-ink/5 flex items-center rounded-[10px] px-2.5 py-[9px] text-[#1d1d1f] opacity-75 transition-[background-color,opacity] hover:opacity-100"
+            >
+              <Github className="h-[15px] w-[15px]" strokeWidth={2.5} />
+            </a>
             <div className="hover:bg-ink/5 rounded-[10px] px-2.5 py-[9px] transition-colors">
               <LanguageSwitcher />
             </div>
@@ -351,7 +361,16 @@ export function Navbar({ t }: NavbarProps) {
             </Fragment>
           ))}
           <div className="mx-3.5 my-2 h-px bg-[#e6eaf5]" />
-          <div className="px-3.5 py-2">
+          <div className="flex items-center gap-4 px-3.5 py-2">
+            <a
+              href={routes.external.github.repo}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={t.github}
+              className="flex items-center text-[#1d1d1f] opacity-75 transition-opacity hover:opacity-100"
+            >
+              <Github className="h-[15px] w-[15px]" strokeWidth={2.5} />
+            </a>
             <LanguageSwitcher />
           </div>
         </div>

--- a/apps/web/src/app/[lang]/i18n/home.i18n.de.json
+++ b/apps/web/src/app/[lang]/i18n/home.i18n.de.json
@@ -42,6 +42,7 @@
       "aiSkills": "KI-Skills",
       "signIn": "Anmelden",
       "createAccount": "Account erstellen",
+      "github": "scibly auf GitHub",
       "skipToContent": "Zum Inhalt springen",
       "openMenu": "Menü öffnen",
       "closeMenu": "Menü schließen"

--- a/apps/web/src/app/[lang]/i18n/home.i18n.en.json
+++ b/apps/web/src/app/[lang]/i18n/home.i18n.en.json
@@ -42,6 +42,7 @@
       "aiSkills": "AI Skills",
       "signIn": "Log in",
       "createAccount": "Create account",
+      "github": "scibly on GitHub",
       "skipToContent": "Skip to content",
       "openMenu": "Open menu",
       "closeMenu": "Close menu"

--- a/apps/web/src/app/[lang]/i18n/home.types.ts
+++ b/apps/web/src/app/[lang]/i18n/home.types.ts
@@ -17,6 +17,7 @@ export type HomePage = {
     aiSkills: string;
     signIn: string;
     createAccount: string;
+    github: string;
     skipToContent: string;
     openMenu: string;
     closeMenu: string;


### PR DESCRIPTION
## What & why

Two changes to the marketing home page.

**A GitHub link in the navbar.** It sits immediately left of the language switcher and points at `routes.external.github.repo`. It borrows the switcher's own treatment — 15px icon, `strokeWidth 2.5`, 75% opacity, the same `hover:bg-ink/5` pill — so the two read as one cluster rather than a button parked next to an icon. Because it is icon-only, the accessible name comes from a new `navbar.github` key ("scibly auf GitHub" / "scibly on GitHub"); the mobile drawer gets the same pairing next to its switcher.

**The demo CTA moves from the security section to the founder quote.** Asking to talk to the founders is a natural next beat after reading what they have to say, whereas the security section is a list of claims people scan rather than a place they decide from. Both buttons anchor to `#cta-section`, so this relocates the existing call to action rather than adding a second one — the `cta` key moves from `ComplianceDictionary` to `FounderDictionary` along with it, and the security header keeps its eyebrow, title, and subtitle.

### Notes for review

- The founder button reuses `actionClass + primaryActionClass` and the same `ArrowRight` hover nudge as the button it replaces, so nothing new enters the design language.
- `founder.tsx` stays a server component — the button anchors to the CTA section rather than opening Calendly directly, matching what the security section did.
- Verified in a running dev server on both locales: nav order is `Account erstellen → scibly auf GitHub → Sprache wechseln`, the founder card renders its button, and the security section now contains zero links.

## Checklist

- [x] `pnpm check` passes (typecheck + lint + format) — 32/32 tasks
- [x] `pnpm test:unit` passes — 10/10 tasks
- [x] For `apps/app`/`apps/web` changes, ran `pnpm --filter <@scibly/app|@scibly/web> run format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
