### PR TITLE
Collect: merged PRs to knowledge event bundles

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=22"
+    "node": ">=22.5"
   },
   "scripts": {
     "preview": "next build && next start",

--- a/apps/app/src/app/[lang]/profile/org/[orgSlug]/knowledge/[topicId]/page.tsx
+++ b/apps/app/src/app/[lang]/profile/org/[orgSlug]/knowledge/[topicId]/page.tsx
@@ -1,0 +1,7 @@
+import { KnowledgeTopicScreen } from "@/features/knowledge/topic-screen";
+
+export default function KnowledgeTopicPage(props: {
+  params: Promise<{ lang: string; orgSlug: string; topicId: string }>;
+}) {
+  return <KnowledgeTopicScreen {...props} />;
+}

--- a/apps/app/src/features/integrations/api/integration-connection-procedures.ts
+++ b/apps/app/src/features/integrations/api/integration-connection-procedures.ts
@@ -35,15 +35,18 @@ import {
   searchPagesSchema,
 } from "./integration.schema";
 
-const PROXY_LIMIT = {
-  endpoint: "integration.proxy",
-  maxPerWindow: 300,
-  tooManyRequestsMessage:
-    "Too many integration requests. Please try again in a bit.",
-} as const;
-
 const boundedProxy = <T>(userId: string, ask: () => Promise<T>) =>
-  withRateLimit({ db, identifier: userId, ...PROXY_LIMIT }, ask);
+  withRateLimit(
+    {
+      db,
+      identifier: userId,
+      endpoint: "integration.proxy",
+      maxPerWindow: 300,
+      tooManyRequestsMessage:
+        "Too many integration requests. Please try again in a bit.",
+    },
+    ask,
+  );
 
 export async function resolveConnectionRow(
   organizationId: string,

--- a/apps/app/src/features/integrations/contracts.ts
+++ b/apps/app/src/features/integrations/contracts.ts
@@ -71,20 +71,18 @@ export interface IntegrationGrantList {
   totalCount: number;
 }
 
-export interface OAuthTokens {
-  accessToken: string;
-  workspaceId?: string;
-  workspaceName?: string;
-}
-
-export interface AppInstallation {
-  installationId: string;
-  workspaceId?: string;
-  workspaceName?: string;
-}
-
 export type IntegrationCredential =
-  | ({ kind: "oauth_tokens" } & OAuthTokens)
-  | ({ kind: "app_installation" } & AppInstallation);
+  | {
+      kind: "oauth_tokens";
+      accessToken: string;
+      workspaceId?: string;
+      workspaceName?: string;
+    }
+  | {
+      kind: "app_installation";
+      installationId: string;
+      workspaceId?: string;
+      workspaceName?: string;
+    };
 
 export type IntegrationCredentialKind = IntegrationCredential["kind"];

--- a/apps/app/src/features/integrations/server.ts
+++ b/apps/app/src/features/integrations/server.ts
@@ -10,4 +10,14 @@ export { handleIntegrationConnectCallback } from "./server/connect-callback";
 export { resolveConnectionToken } from "./server/connection-token";
 export { integrationPoll, integrationSync } from "./server/integration-sync";
 export { buildIntegrationNotebookTools } from "./server/notebook-tools";
+export type {
+  PullRequestComment,
+  PullRequestDetail,
+  PullRequestSummary,
+  PullRequestThread,
+} from "./server/providers/github/pull-requests";
+export {
+  fetchPullRequestDetail,
+  listMergedPullRequests,
+} from "./server/providers/github/pull-requests";
 export { getPageProvider } from "./server/registry";

--- a/apps/app/src/features/integrations/server/base-provider.ts
+++ b/apps/app/src/features/integrations/server/base-provider.ts
@@ -39,13 +39,6 @@ export abstract class IntegrationProvider {
   mintAccessToken?(installationId: string): Promise<string>;
 
   listGrants?(token: string): Promise<IntegrationGrantList>;
-
-  resolveGrant?(
-    token: string,
-    grantId: string,
-  ): Promise<IntegrationGrant | null>;
-
-  listFolders?(token: string, grantId: string): Promise<string[]>;
 }
 
 export abstract class RepositoryIntegrationProvider extends IntegrationProvider {

--- a/apps/app/src/features/integrations/server/connect-callback.ts
+++ b/apps/app/src/features/integrations/server/connect-callback.ts
@@ -1,12 +1,8 @@
 import type {
   IntegrationCallbackError,
-  IntegrationCredential,
   IntegrationProviderId,
 } from "../contracts";
-import type {
-  ConnectCallbackParams,
-  IntegrationProvider,
-} from "./base-provider";
+import type { ConnectCallbackParams } from "./base-provider";
 
 import { getSession } from "@scibly/auth/session";
 import { db } from "@scibly/db";
@@ -55,21 +51,6 @@ function errorRedirect(
 
 function providerError(oauthError: string): IntegrationCallbackError {
   return oauthError === "access_denied" ? "provider_denied" : "provider_error";
-}
-
-function readCallbackParams(
-  searchParams: URLSearchParams,
-  provider: IntegrationProvider,
-): ConnectCallbackParams | null {
-  const params: ConnectCallbackParams = {
-    code: searchParams.get("code"),
-    installationId: searchParams.get("installation_id"),
-  };
-  const required =
-    provider.credential === "app_installation"
-      ? params.installationId
-      : params.code;
-  return required ? params : null;
 }
 
 function validateCallback(
@@ -127,8 +108,15 @@ function validateCallback(
     return { ok: false, destination, reason: "state_mismatch" };
   }
 
-  const params = readCallbackParams(searchParams, getProvider(provider));
-  if (!params) {
+  const params: ConnectCallbackParams = {
+    code: searchParams.get("code"),
+    installationId: searchParams.get("installation_id"),
+  };
+  const required =
+    getProvider(provider).credential === "app_installation"
+      ? params.installationId
+      : params.code;
+  if (!required) {
     return { ok: false, destination, reason: "missing_params" };
   }
 
@@ -167,20 +155,6 @@ async function authorizeCallback(
   }
 }
 
-// The two shapes use disjoint columns, and each connect clears the other's.
-function credentialColumns(credential: IntegrationCredential) {
-  if (credential.kind === "app_installation") {
-    return {
-      accessTokenEncrypted: null,
-      installationId: credential.installationId,
-    };
-  }
-  return {
-    accessTokenEncrypted: encryptApiKey(credential.accessToken),
-    installationId: null,
-  };
-}
-
 async function completeAndPersistConnection(
   callback: ValidCallback,
   organizationId: string,
@@ -198,7 +172,16 @@ async function completeAndPersistConnection(
   };
 
   const connectionData = {
-    ...credentialColumns(credential),
+    // The two credential shapes use disjoint columns, and each connect clears the other's.
+    ...(credential.kind === "app_installation"
+      ? {
+          accessTokenEncrypted: null,
+          installationId: credential.installationId,
+        }
+      : {
+          accessTokenEncrypted: encryptApiKey(credential.accessToken),
+          installationId: null,
+        }),
     workspaceId: credential.workspaceId ?? null,
     workspaceName: credential.workspaceName ?? null,
 

--- a/apps/app/src/features/integrations/server/connection-token.ts
+++ b/apps/app/src/features/integrations/server/connection-token.ts
@@ -33,24 +33,6 @@ function revoked(provider: string): AppError {
   });
 }
 
-async function forgetRevokedConnection(
-  connection: ConnectionCredential,
-  providerId: IntegrationProviderId,
-): Promise<void> {
-  await db.$transaction(async (tx) => {
-    await warnSourcesOfLostConnection(
-      connection.id,
-      providerId,
-      "disconnected",
-      tx,
-    );
-    await tx.integrationConnection.updateMany({
-      where: { id: connection.id },
-      data: DISCONNECTED_CREDENTIAL,
-    });
-  });
-}
-
 export async function resolveConnectionToken(
   connection: ConnectionCredential,
 ): Promise<string> {
@@ -62,7 +44,18 @@ export async function resolveConnectionToken(
       return await provider.mintAccessToken(connection.installationId);
     } catch (error) {
       if (!(error instanceof IntegrationRevokedError)) throw error;
-      await forgetRevokedConnection(connection, provider.providerId);
+      await db.$transaction(async (tx) => {
+        await warnSourcesOfLostConnection(
+          connection.id,
+          provider.providerId,
+          "disconnected",
+          tx,
+        );
+        await tx.integrationConnection.updateMany({
+          where: { id: connection.id },
+          data: DISCONNECTED_CREDENTIAL,
+        });
+      });
       throw revoked(provider.providerId);
     }
   }

--- a/apps/app/src/features/integrations/server/detach-sources.ts
+++ b/apps/app/src/features/integrations/server/detach-sources.ts
@@ -5,10 +5,6 @@ import { db, type Prisma } from "@scibly/db";
 type DetachReason = "disconnected" | "workspace_changed";
 type Tx = Prisma.TransactionClient | typeof db;
 
-function disconnectWarning(provider: IntegrationProviderId): string {
-  return `The ${provider} integration is disconnected. Reconnect it to resume syncing.`;
-}
-
 export async function warnSourcesOfLostConnection(
   connectionId: string,
   provider: IntegrationProviderId,
@@ -19,7 +15,9 @@ export async function warnSourcesOfLostConnection(
     where: { integrationId: connectionId },
     data:
       reason === "disconnected"
-        ? { warning: disconnectWarning(provider) }
+        ? {
+            warning: `The ${provider} integration is disconnected. Reconnect it to resume syncing.`,
+          }
         : {
             integrationId: null,
             warning: `The ${provider} integration was reconnected to a different workspace. This source will no longer sync automatically — re-link the page from the new workspace to resume syncing.`,

--- a/apps/app/src/features/integrations/server/integration-sync.test.ts
+++ b/apps/app/src/features/integrations/server/integration-sync.test.ts
@@ -39,17 +39,6 @@ describe("KC1: one run per due connection", () => {
     ]);
   });
 
-  it("carries the provider, which is what the concurrency cap groups on", async () => {
-    sync.loadDueConnections.mockResolvedValue([
-      { id: "conn-a", provider: "NOTION" },
-    ]);
-
-    await requestDuePolls(sendEvent);
-
-    const [, events] = sendEvent.mock.calls[0];
-    expect(events[0].data.provider).toBe("NOTION");
-  });
-
   it("sends nothing when nothing is due", async () => {
     expect(await requestDuePolls(sendEvent)).toEqual({ requested: 0 });
     expect(sendEvent).not.toHaveBeenCalled();

--- a/apps/app/src/features/integrations/server/providers/github/app-auth.ts
+++ b/apps/app/src/features/integrations/server/providers/github/app-auth.ts
@@ -82,13 +82,11 @@ async function githubRequest<T>(
         "x-github-api-version": "2022-11-28",
       },
       cache: "no-store",
-      // `fetch` waits forever by default, and one hung request must not spend a whole sync hop.
       signal: AbortSignal.timeout(GITHUB_TIMEOUT_MS),
     },
   );
 
   if (!response.ok) {
-    // The request carried a JWT or a minted token, so nothing but GitHub's own status and message goes into an error a caller may log.
     const message = await response
       .json()
       .then((body: { message?: string }) => body.message)
@@ -99,6 +97,58 @@ async function githubRequest<T>(
     );
   }
   return schema.parse(await response.json());
+}
+
+const graphqlEnvelope = z.object({
+  data: z.unknown().nullable().optional(),
+  errors: z
+    .array(z.object({ type: z.string().optional(), message: z.string() }))
+    .optional(),
+});
+
+export async function githubGraphQL<T>(
+  token: string,
+  query: string,
+  variables: Record<string, string | number | null>,
+  schema: z.ZodType<T>,
+): Promise<T> {
+  const response = await fetch(routes.external.integrations.github.graphql, {
+    method: "POST",
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+    cache: "no-store",
+    signal: AbortSignal.timeout(GITHUB_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new GitHubRequestError(
+      `GitHub GraphQL failed: ${response.status}`,
+      response.status,
+    );
+  }
+
+  const body = graphqlEnvelope.parse(await response.json());
+  const [failure] = body.errors ?? [];
+  if (failure) {
+    // GraphQL answers 200 with an `errors` array; `type` is mapped onto a status so the REST callers' 404-means-unreachable rule still holds.
+    const status =
+      failure.type === "NOT_FOUND"
+        ? 404
+        : failure.type === "FORBIDDEN"
+          ? 403
+          : failure.type === "RATE_LIMITED"
+            ? 429
+            : 502;
+    throw new GitHubRequestError(
+      `GitHub GraphQL failed: ${failure.message}`,
+      status,
+    );
+  }
+  return schema.parse(body.data);
 }
 
 const installationResponse = z.object({
@@ -314,7 +364,6 @@ export async function fetchInstallationRepositories(
     totalCount = body.total_count;
     const returned = body.repositories ?? [];
     repositories.push(...returned);
-    // A short page is the last page, whatever the count claims.
     if (returned.length < REPOS_PER_PAGE) break;
     if (repositories.length >= totalCount) break;
   }

--- a/apps/app/src/features/integrations/server/providers/github/pull-requests.ts
+++ b/apps/app/src/features/integrations/server/providers/github/pull-requests.ts
@@ -1,0 +1,273 @@
+import { z } from "zod";
+
+import { githubGraphQL, GitHubRequestError } from "./app-auth";
+
+// GitHub's `IssueOrderField` cannot order by merge date, so collection walks
+// UPDATED_AT descending and stops at its watermark.
+const LIST_QUERY = `
+  query($owner: String!, $name: String!, $pageSize: Int!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+      pullRequests(
+        first: $pageSize
+        states: MERGED
+        orderBy: { field: UPDATED_AT, direction: DESC }
+        after: $cursor
+      ) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          number
+          title
+          updatedAt
+          mergedAt
+          permalink
+          totalCommentsCount
+          author { __typename login }
+          labels(first: 20) { nodes { name } }
+        }
+      }
+    }
+  }
+`;
+
+// Node count is bounded by the `first` arguments multiplied together (~760),
+// well inside GitHub's limit.
+const DETAIL_QUERY = `
+  query($id: ID!) {
+    node(id: $id) {
+      ... on PullRequest {
+        id
+        number
+        title
+        bodyText
+        permalink
+        mergedAt
+        updatedAt
+        labels(first: 20) { nodes { name } }
+        files(first: 100) { pageInfo { hasNextPage } nodes { path } }
+        closingIssuesReferences(first: 10) { nodes { number title url } }
+        comments(first: 50) { nodes { bodyText url author { login } } }
+        reviewThreads(first: 30) {
+          nodes {
+            path
+            isResolved
+            comments(first: 20) {
+              nodes { bodyText url diffHunk author { login } }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const named = <T extends z.ZodTypeAny>(node: T) =>
+  z.object({ nodes: z.array(node).nullable().optional() });
+
+const summaryNode = z.object({
+  id: z.string(),
+  number: z.number(),
+  title: z.string(),
+  updatedAt: z.string(),
+  mergedAt: z.string().nullable(),
+  permalink: z.string(),
+  totalCommentsCount: z.number().nullable(),
+  author: z.object({ __typename: z.string(), login: z.string() }).nullable(),
+  labels: named(z.object({ name: z.string() })).nullable(),
+});
+
+type MergedNode = z.infer<typeof summaryNode> & { mergedAt: string };
+
+const listResponse = z.object({
+  repository: z
+    .object({
+      pullRequests: z.object({
+        pageInfo: z.object({
+          hasNextPage: z.boolean(),
+          endCursor: z.string().nullable(),
+        }),
+        nodes: z.array(summaryNode.nullable()).nullable().optional(),
+      }),
+    })
+    .nullable(),
+});
+
+const threadComment = z.object({
+  bodyText: z.string(),
+  url: z.string(),
+  diffHunk: z.string().nullable().optional(),
+  author: z.object({ login: z.string() }).nullable(),
+});
+
+const detailResponse = z.object({
+  node: z
+    .object({
+      id: z.string(),
+      number: z.number(),
+      title: z.string(),
+      bodyText: z.string(),
+      permalink: z.string(),
+      mergedAt: z.string().nullable(),
+      updatedAt: z.string(),
+      labels: named(z.object({ name: z.string() })).nullable(),
+      files: named(z.object({ path: z.string() }))
+        .extend({ pageInfo: z.object({ hasNextPage: z.boolean() }) })
+        .nullable(),
+      closingIssuesReferences: named(
+        z.object({ number: z.number(), title: z.string(), url: z.string() }),
+      ).nullable(),
+      comments: named(threadComment).nullable(),
+      reviewThreads: named(
+        z.object({
+          path: z.string().nullable(),
+          isResolved: z.boolean(),
+          comments: named(threadComment).nullable(),
+        }),
+      ).nullable(),
+    })
+    .nullable(),
+});
+
+const nodesOf = <T>(
+  connection: { nodes?: (T | null)[] | null } | null | undefined,
+): T[] => (connection?.nodes ?? []).filter((node): node is T => node !== null);
+
+export interface PullRequestSummary {
+  externalId: string;
+  number: number;
+  title: string;
+  /** Null when the account was deleted. */
+  authorLogin: string | null;
+  /** GraphQL's own `__typename` — "Bot" for a GitHub App, "User" for a person. */
+  authorType: string | null;
+  labels: string[];
+  commentCount: number;
+  updatedAt: Date;
+  mergedAt: Date;
+  url: string;
+}
+
+export interface PullRequestComment {
+  author: string | null;
+  body: string;
+  url: string;
+  /** Only a review comment hangs off a diff. */
+  diffHunk: string | null;
+}
+
+export interface PullRequestThread {
+  path: string | null;
+  isResolved: boolean;
+  comments: PullRequestComment[];
+}
+
+export interface PullRequestDetail {
+  externalId: string;
+  number: number;
+  title: string;
+  body: string;
+  url: string;
+  labels: string[];
+  filePaths: string[];
+  filesTruncated: boolean;
+  linkedIssues: { number: number; title: string; url: string }[];
+  comments: PullRequestComment[];
+  threads: PullRequestThread[];
+  mergedAt: Date;
+  updatedAt: Date;
+}
+
+const asComment = (comment: z.infer<typeof threadComment>) => ({
+  author: comment.author?.login ?? null,
+  body: comment.bodyText,
+  url: comment.url,
+  diffHunk: comment.diffHunk ?? null,
+});
+
+// Takes `repositoryFullName` rather than the id the REST calls take: GraphQL
+// has no way to reach a repository by its database id.
+export async function listMergedPullRequests(
+  token: string,
+  repositoryFullName: string,
+  options: { pageSize: number; cursor?: string | null },
+): Promise<{
+  pullRequests: PullRequestSummary[];
+  nextCursor: string | null;
+}> {
+  const [owner, name] = repositoryFullName.split("/");
+  const { repository } = await githubGraphQL(
+    token,
+    LIST_QUERY,
+    {
+      owner,
+      name,
+      pageSize: options.pageSize,
+      cursor: options.cursor ?? null,
+    },
+    listResponse,
+  );
+  if (!repository) return { pullRequests: [], nextCursor: null };
+
+  const { pageInfo, nodes } = repository.pullRequests;
+  return {
+    pullRequests: nodesOf({ nodes })
+      // A null merge date would poison the watermark, so it is dropped rather than trusted.
+      .filter((node): node is MergedNode => node.mergedAt !== null)
+      .map((node) => ({
+        externalId: node.id,
+        number: node.number,
+        title: node.title,
+        authorLogin: node.author?.login ?? null,
+        authorType: node.author?.__typename ?? null,
+        labels: nodesOf(node.labels).map((label) => label.name),
+        commentCount: node.totalCommentsCount ?? 0,
+        updatedAt: new Date(node.updatedAt),
+        mergedAt: new Date(node.mergedAt),
+        url: node.permalink,
+      })),
+    nextCursor: pageInfo.hasNextPage ? pageInfo.endCursor : null,
+  };
+}
+
+/** Null when the pull request has since been deleted or moved out of reach. */
+export async function fetchPullRequestDetail(
+  token: string,
+  externalId: string,
+): Promise<PullRequestDetail | null> {
+  let node: z.infer<typeof detailResponse>["node"];
+  try {
+    ({ node } = await githubGraphQL(
+      token,
+      DETAIL_QUERY,
+      { id: externalId },
+      detailResponse,
+    ));
+  } catch (error) {
+    // GitHub reports a deleted node as a NOT_FOUND error entry, not a null node.
+    if (error instanceof GitHubRequestError && error.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+  if (!node?.mergedAt) return null;
+
+  return {
+    externalId: node.id,
+    number: node.number,
+    title: node.title,
+    body: node.bodyText,
+    url: node.permalink,
+    labels: nodesOf(node.labels).map((label) => label.name),
+    filePaths: nodesOf(node.files).map((file) => file.path),
+    filesTruncated: node.files?.pageInfo.hasNextPage ?? false,
+    linkedIssues: nodesOf(node.closingIssuesReferences),
+    comments: nodesOf(node.comments).map(asComment),
+    threads: nodesOf(node.reviewThreads).map((thread) => ({
+      path: thread.path,
+      isResolved: thread.isResolved,
+      comments: nodesOf(thread.comments).map(asComment),
+    })),
+    mergedAt: new Date(node.mergedAt),
+    updatedAt: new Date(node.updatedAt),
+  };
+}

--- a/apps/app/src/features/integrations/server/sync-source-freshness.test.ts
+++ b/apps/app/src/features/integrations/server/sync-source-freshness.test.ts
@@ -23,7 +23,6 @@ vi.mock("@/features/integrations/server/registry", () => registry);
 vi.mock("@/features/integrations/server/connection-token", () => token);
 
 const {
-  backoffMs,
   getPollingStart,
   loadDueConnections,
   pollConnection,
@@ -442,13 +441,6 @@ describe("KW1/KW2/KF2/KF3/KF4: what an attempt writes down", () => {
       });
     },
   );
-
-  it("KF3: the backoff table is what the counter indexes into", () => {
-    expect(backoffMs(0)).toBe(0);
-    expect(backoffMs(3)).toBe(6 * HOUR);
-
-    expect(backoffMs(99)).toBe(3 * DAY);
-  });
 
   it("KF4: any success clears the backoff and the failure count", async () => {
     sources({ id: "src-a", externalId: "page-a" });

--- a/apps/app/src/features/integrations/server/sync-source-freshness.ts
+++ b/apps/app/src/features/integrations/server/sync-source-freshness.ts
@@ -29,7 +29,7 @@ const SYNC_BACKOFF_MS: readonly number[] = [
 // window that starts after the changes it slept through.
 const SYNC_BACKOFF_CAP_MS = TimeHelpers.IN_MS.DAY * 3;
 
-export function backoffMs(consecutiveFailures: number): number {
+function backoffMs(consecutiveFailures: number): number {
   return SYNC_BACKOFF_MS[consecutiveFailures] ?? SYNC_BACKOFF_CAP_MS;
 }
 
@@ -56,19 +56,6 @@ export async function loadDueConnections(
 }
 
 type SyncableSource = { id: string; externalId: string | null };
-
-async function loadSyncableSources(
-  integrationId: string,
-): Promise<SyncableSource[]> {
-  return db.notebookSource.findMany({
-    where: {
-      integrationId,
-      status: SOURCE_STATUS.READY,
-      externalId: { not: null },
-    },
-    select: { id: true, externalId: true },
-  });
-}
 
 export function getPollingStart(lastPolledAt: Date | null, now: Date): Date {
   const floor = now.getTime() - SYNC_WINDOW_FLOOR_MS;
@@ -153,7 +140,14 @@ export async function pollConnection(
   });
   if (!connection || !isConnected(connection)) return { status: "gone" };
 
-  const sources = await loadSyncableSources(connection.id);
+  const sources = await db.notebookSource.findMany({
+    where: {
+      integrationId: connection.id,
+      status: SOURCE_STATUS.READY,
+      externalId: { not: null },
+    },
+    select: { id: true, externalId: true },
+  });
   if (sources.length === 0) {
     await recordAttempt(connection.id, pollSucceeded(now));
     return { status: "empty" };

--- a/apps/app/src/features/integrations/settings/components/org-integrations/org-integrations-card.tsx
+++ b/apps/app/src/features/integrations/settings/components/org-integrations/org-integrations-card.tsx
@@ -8,17 +8,15 @@ import { DisconnectIntegrationDialog } from "./disconnect-integration-dialog";
 import { ProviderRow } from "./provider-row";
 import { useOrgIntegrations } from "./use-org-integrations";
 
-interface OrgIntegrationsCardProps {
-  orgSlug: string;
-  lang: string;
-  t: OrgSettingsPage["integrations"];
-}
-
 export function OrgIntegrationsCard({
   orgSlug,
   lang,
   t,
-}: OrgIntegrationsCardProps) {
+}: {
+  orgSlug: string;
+  lang: string;
+  t: OrgSettingsPage["integrations"];
+}) {
   const {
     connections,
     allProviders,

--- a/apps/app/src/features/knowledge/CONTEXT.md
+++ b/apps/app/src/features/knowledge/CONTEXT.md
@@ -3,10 +3,12 @@
 What an organization wants written down about its own code, and kept true as
 that code moves. A topic states the intent — this document, about this much of
 these repositories — and names who is trusted to judge what the sync later
-proposes for it. A topic now also has a document: markdown held here, projected
-onto a Notion page the organization can read and edit. This context decides
-scope, stewardship, and where the projection lands; noticing a change, drafting
-a suggestion, and metering the cost belong to the tickets that follow.
+proposes for it. A topic also has a document: markdown held here, projected onto
+a Notion page the organization can read and edit. The sync now collects too: a
+merged pull request worth learning from becomes a bundle. This context decides
+scope, stewardship, where the projection lands, and what is worth keeping;
+reading a bundle, drafting a suggestion, and metering the cost belong to the
+tickets that follow.
 
 ## Language
 
@@ -67,7 +69,53 @@ German topic.
 _Avoid_: locale (the app's word for what a reader sees)
 
 **Health**:
-What a topic looks like at a glance — when it last synced, how much is waiting
-on a maintainer. Every value is a placeholder until the syncing tickets land;
-the surface says "never" rather than inventing a number.
+What a topic looks like at a glance — when it last collected, and how much is
+waiting on a maintainer. The collection half is real; how much waits on a
+maintainer stays a placeholder until suggestions land.
 _Avoid_: status, state
+
+## What the sync collects
+
+**Bundle**:
+One merged pull request kept whole, because the argument in it is worth
+learning from: its title, description, labels, file paths, linked issues, and
+every review thread with the diff it hangs off. Held for the organization
+against the repository it came from, never for one topic — the same pull
+request feeds every topic watching that repository.
+_Avoid_: knowledge event, snapshot, record, PR (GitHub's word for the thing a
+bundle is made from)
+
+**Discarded**:
+What a pull request is when the filter refuses it. Nothing of it is kept but
+what proves it was already judged — its id, when GitHub last saw it move, and
+the reason. A discarded pull request is judged again only if it moves on
+GitHub, so an argument that arrives after the merge still has its chance.
+_Avoid_: rejected, filtered, skipped, deleted
+
+**Structural filter**:
+The judgement made before anything is fetched in full or stored, and made
+without a model: a bot's pull request, or a chore with nothing said on it, is
+refused outright, and the rest are ranked on how much was argued. It costs
+nothing but the listing, which is the point — the model stages downstream are
+what the funnel is narrow for.
+_Avoid_: triage (the model stage in the ticket that follows), heuristic, rules
+
+**Collection run**:
+One repository's turn at collecting, for one organization. It says how far it
+got, what it kept, what it refused, and whether it stopped early on a budget
+rather than on running out. A run is the only thing that moves a watermark, and
+only a run that succeeded moves it.
+_Avoid_: sync (integrations' word for a whole scheduled pass), job, poll
+
+**Watermark**:
+Defined in [integrations](../integrations/CONTEXT.md). Here it is per
+repository rather than per connection, and it marks how recently a pull request
+was touched, not when it merged — GitHub will not order by the merge, and a
+merged pull request that is argued over afterwards should come back.
+
+**Activity feed**:
+What a topic can show for itself: its recent collection runs, and the bundles
+they kept from the repositories it watches, narrowed to its path globs. It is
+read, not stored — nothing binds a bundle to a topic until the tickets that
+follow do.
+_Avoid_: history, log, timeline

--- a/apps/app/src/features/knowledge/api/knowledge-topic-procedures.ts
+++ b/apps/app/src/features/knowledge/api/knowledge-topic-procedures.ts
@@ -1,3 +1,4 @@
+import { AppError } from "@scibly/api/application-error";
 import {
   assertAllowed,
   decideKnowledgeSync,
@@ -9,7 +10,10 @@ import { db } from "@scibly/db";
 
 import { resolveRepositoryConnection } from "@/features/integrations/server";
 import { resolveOrg } from "@/features/organizations/server";
+import { inngest } from "@/lib/inngest/client";
 
+import { requestCollections } from "../server/collect/collection-sync";
+import { loadTopicFeed } from "../server/collect/topic-feed";
 import {
   createTopicDocument,
   readDocumentDestination,
@@ -29,10 +33,10 @@ import {
 } from "../server/topic-view";
 import {
   createTopicSchema,
-  deleteTopicSchema,
   listFoldersSchema,
   orgSlugInput,
   setDocumentDestinationSchema,
+  topicIdSchema,
   updateTopicSchema,
 } from "./knowledge.schema";
 
@@ -41,6 +45,12 @@ const FOLDERS_LIMIT = {
   maxPerWindow: 120,
   tooManyRequestsMessage:
     "Too many folder listings. Please try again in a bit.",
+} as const;
+
+const SYNC_LIMIT = {
+  endpoint: "knowledge.syncNow",
+  maxPerWindow: 20,
+  tooManyRequestsMessage: "Too many syncs. Please try again in a bit.",
 } as const;
 
 const WRITE_LIMIT = {
@@ -53,6 +63,33 @@ async function requireKnowledgeAdmin(orgSlug: string, userId: string) {
   const { organization } = await resolveOrg(orgSlug, userId, "admin_or_owner");
   assertAllowed(await decideKnowledgeSync(db, organization.id));
   return { organizationId: organization.id };
+}
+
+async function resolveTopicAccess(
+  orgSlug: string,
+  userId: string,
+  topicId: string,
+) {
+  const { organization, membership } = await resolveOrg(
+    orgSlug,
+    userId,
+    "member",
+  );
+  const topic = await db.knowledgeTopic.findFirst({
+    where: { id: topicId, organizationId: organization.id },
+    select: TOPIC_SELECT,
+  });
+  if (!topic) throw topicNotFound();
+
+  const canManage = membership.role === "admin" || membership.role === "owner";
+  return {
+    organizationId: organization.id,
+    topic,
+    canManage,
+    canSync:
+      canManage ||
+      topic.maintainers.some((maintainer) => maintainer.id === membership.id),
+  };
 }
 
 export const knowledgeTopicProcedures = {
@@ -83,6 +120,70 @@ export const knowledgeTopicProcedures = {
       canManage,
     };
   }),
+
+  get: protectedProcedure.input(topicIdSchema).query(async ({ input, ctx }) => {
+    const { organizationId, topic, canManage, canSync } =
+      await resolveTopicAccess(
+        input.orgSlug,
+        ctx.session.user.id,
+        input.topicId,
+      );
+    const view = toTopicView(topic);
+    const [feed, access] = await Promise.all([
+      loadTopicFeed(organizationId, view.repositories),
+      describeKnowledgeSyncAccess(db, organizationId),
+    ]);
+    // Raw provider error text is for those who can act on it; everyone else
+    // still sees the run as failed.
+    const runs = canManage
+      ? feed.runs
+      : feed.runs.map((run) => ({ ...run, failureReason: null }));
+    return {
+      organizationId,
+      topic: view,
+      runs,
+      bundles: feed.bundles,
+      access,
+      canManage,
+      canSync,
+    };
+  }),
+
+  syncNow: protectedProcedure
+    .input(topicIdSchema)
+    .mutation(async ({ input, ctx }) => {
+      const { organizationId, topic, canSync } = await resolveTopicAccess(
+        input.orgSlug,
+        ctx.session.user.id,
+        input.topicId,
+      );
+      if (!canSync) {
+        throw new AppError({
+          code: "FORBIDDEN",
+          applicationCode: "organization.access_denied",
+          message:
+            "Only an admin or one of this topic's maintainers can sync it.",
+        });
+      }
+      assertAllowed(await decideKnowledgeSync(db, organizationId));
+
+      // Keyed by organization: what a sync spends is the installation's GitHub
+      // quota, which every maintainer draws on together.
+      return withRateLimit(
+        { db, identifier: organizationId, ...SYNC_LIMIT },
+        async () => {
+          const { requested } = await requestCollections(
+            toTopicView(topic).repositories.map(
+              (repository): [string, string] => [organizationId, repository.id],
+            ),
+            async (events) => {
+              await inngest.send(events);
+            },
+          );
+          return { queued: requested };
+        },
+      );
+    }),
 
   listFolders: protectedProcedure
     .input(listFoldersSchema)
@@ -212,7 +313,7 @@ export const knowledgeTopicProcedures = {
     }),
 
   delete: protectedProcedure
-    .input(deleteTopicSchema)
+    .input(topicIdSchema)
     .mutation(async ({ input, ctx }) => {
       // No plan gate: an organization's own data stays theirs to remove.
       const { organization } = await resolveOrg(

--- a/apps/app/src/features/knowledge/api/knowledge-topics.test.ts
+++ b/apps/app/src/features/knowledge/api/knowledge-topics.test.ts
@@ -2,7 +2,6 @@ import { routes } from "@scibly/routes";
 import { rateLimitCounter } from "@test/mocks/rate-limit-counter";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// Real tRPC caller over the real router, so the schema and the gate both run for real; only the database, the org lookup and the GitHub connection are doubled.
 const db = vi.hoisted(() => ({
   knowledgeTopic: {
     findMany: vi.fn(),
@@ -19,6 +18,10 @@ const db = vi.hoisted(() => ({
 const resolveOrg = vi.hoisted(() => vi.fn());
 const resolveRepositoryConnection = vi.hoisted(() => vi.fn());
 const resolvePageConnection = vi.hoisted(() => vi.fn());
+const collect = vi.hoisted(() => ({
+  requestCollections: vi.fn(),
+}));
+const inngestSend = vi.hoisted(() => vi.fn());
 
 vi.mock("@scibly/db", () => ({
   db,
@@ -33,6 +36,8 @@ vi.mock("@scibly/db", () => ({
   },
 }));
 vi.mock("@/features/organizations/server", () => ({ resolveOrg }));
+vi.mock("../server/collect/collection-sync", () => collect);
+vi.mock("@/lib/inngest/client", () => ({ inngest: { send: inngestSend } }));
 vi.mock("@/features/integrations/server", () => ({
   resolveRepositoryConnection,
   resolvePageConnection,
@@ -926,5 +931,62 @@ describe("deleting a topic leaves the document behind", () => {
 
     expect(resolvePageConnection).not.toHaveBeenCalled();
     expect(db.knowledgeTopic.deleteMany).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("only an admin or a maintainer may sync a topic", () => {
+  const asMember = (role: string, memberId: string) => {
+    resolveOrg.mockResolvedValue({
+      organization: { id: ORG_ID, slug: ORG_SLUG },
+      membership: { id: memberId, role },
+    });
+    db.knowledgeTopic.findFirst.mockResolvedValue(STORED);
+  };
+
+  beforeEach(() => {
+    collect.requestCollections.mockResolvedValue({ requested: 1 });
+  });
+
+  it("refuses a member who maintains nothing, without queueing anything", async () => {
+    asMember("member", "mem-other");
+
+    const error = await refusal(() =>
+      caller().syncNow({ orgSlug: ORG_SLUG, topicId: STORED.id }),
+    );
+
+    expect(error.code).toBe("FORBIDDEN");
+    expect(error.applicationCode).toBe("organization.access_denied");
+    expect(collect.requestCollections).not.toHaveBeenCalled();
+    expect(inngestSend).not.toHaveBeenCalled();
+  });
+
+  it("lets a plain member sync the topic they maintain", async () => {
+    asMember("member", "mem-1");
+
+    expect(
+      await caller().syncNow({ orgSlug: ORG_SLUG, topicId: STORED.id }),
+    ).toEqual({ queued: 1 });
+    expect(collect.requestCollections).toHaveBeenCalledWith(
+      [[ORG_ID, "repo-1"]],
+      expect.any(Function),
+    );
+  });
+
+  it("lets an admin sync a topic they maintain no part of", async () => {
+    asMember("admin", "mem-other");
+
+    expect(
+      await caller().syncNow({ orgSlug: ORG_SLUG, topicId: STORED.id }),
+    ).toEqual({ queued: 1 });
+  });
+
+  it("asks only for membership, so reading the topic is not admin-only", async () => {
+    asMember("member", "mem-other");
+
+    await refusal(() =>
+      caller().syncNow({ orgSlug: ORG_SLUG, topicId: STORED.id }),
+    );
+
+    expect(resolveOrg).toHaveBeenCalledWith(ORG_SLUG, USER_ID, "member");
   });
 });

--- a/apps/app/src/features/knowledge/api/knowledge.schema.ts
+++ b/apps/app/src/features/knowledge/api/knowledge.schema.ts
@@ -10,7 +10,7 @@ import {
 
 export { orgSlugInput };
 
-export const pathGlobInput = z
+const pathGlobInput = z
   .string()
   .trim()
   .refine(
@@ -48,7 +48,7 @@ export const listFoldersSchema = orgSlugInput.extend({
   repositoryId: z.string().min(1),
 });
 
-export const deleteTopicSchema = orgSlugInput.extend({
+export const topicIdSchema = orgSlugInput.extend({
   topicId: z.string().min(1),
 });
 

--- a/apps/app/src/features/knowledge/components/knowledge-gate-notice.tsx
+++ b/apps/app/src/features/knowledge/components/knowledge-gate-notice.tsx
@@ -1,0 +1,29 @@
+import type { KnowledgeTopicsView, KnowledgeTranslations } from "../contracts";
+
+import { FeatureGateNotice } from "@/shared/ui/feature-gate-notice";
+
+export function KnowledgeGateNotice({
+  t,
+  access,
+}: {
+  t: KnowledgeTranslations;
+  access: KnowledgeTopicsView["access"];
+}) {
+  if (access.allowed) return null;
+  const lapsed = access.reason === "lapsed";
+  const plan = access.requiredPlan ?? t.gate.fallbackPlan;
+  return (
+    <FeatureGateNotice
+      title={
+        lapsed
+          ? t.gate.lapsedTitle
+          : t.gate.lockedTitle.replaceAll("{plan}", plan)
+      }
+      description={
+        lapsed
+          ? t.gate.lapsedDescription
+          : t.gate.lockedDescription.replaceAll("{plan}", plan)
+      }
+    />
+  );
+}

--- a/apps/app/src/features/knowledge/components/knowledge-topics-client.tsx
+++ b/apps/app/src/features/knowledge/components/knowledge-topics-client.tsx
@@ -14,9 +14,9 @@ import { toast } from "sonner";
 
 import { api } from "@/shared/api/trpc/client";
 import { ConfirmDeleteDialog } from "@/shared/ui/confirm-delete-dialog";
-import { FeatureGateNotice } from "@/shared/ui/feature-gate-notice";
 
 import { DocumentDestinationCard } from "./document-destination-card";
+import { KnowledgeGateNotice } from "./knowledge-gate-notice";
 import { TopicCard } from "./topic-card";
 import { TopicDialog } from "./topic-dialog";
 
@@ -31,9 +31,7 @@ export function KnowledgeTopicsClient({
 }) {
   const utils = api.useUtils();
   const { data, isError } = api.knowledge.list.useQuery({ orgSlug });
-  const [editing, setEditing] = useState<KnowledgeTopic | null | undefined>(
-    undefined,
-  );
+  const [creating, setCreating] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<KnowledgeTopic | null>(
     null,
   );
@@ -58,30 +56,15 @@ export function KnowledgeTopicsClient({
   }
   if (!data) return null;
   const canWrite = data.canManage && data.access.allowed;
-  const lapsed = data.access.reason === "lapsed";
-  const plan = data.access.requiredPlan ?? t.gate.fallbackPlan;
 
   return (
     <div className="flex flex-col gap-5">
-      {data.access.allowed ? null : (
-        <FeatureGateNotice
-          title={
-            lapsed
-              ? t.gate.lapsedTitle
-              : t.gate.lockedTitle.replaceAll("{plan}", plan)
-          }
-          description={
-            lapsed
-              ? t.gate.lapsedDescription
-              : t.gate.lockedDescription.replaceAll("{plan}", plan)
-          }
-        />
-      )}
+      <KnowledgeGateNotice t={t} access={data.access} />
 
       {canWrite && data.destination ? (
         <div className="flex flex-wrap items-center justify-between gap-3">
           <Button
-            onClick={() => setEditing(null)}
+            onClick={() => setCreating(true)}
             disabled={!data.destination.destinationPageId}
           >
             <Plus className="h-4 w-4" />
@@ -112,9 +95,8 @@ export function KnowledgeTopicsClient({
             <TopicCard
               key={topic.id}
               topic={topic}
-              canEdit={canWrite}
+              orgSlug={orgSlug}
               canDelete={data.canManage}
-              onEdit={() => setEditing(topic)}
               onDelete={() => setPendingDelete(topic)}
               t={t}
             />
@@ -122,16 +104,15 @@ export function KnowledgeTopicsClient({
         </div>
       )}
 
-      {editing === undefined ? null : (
+      {creating ? (
         <TopicDialog
           t={t}
           orgSlug={orgSlug}
           orgId={data.organizationId}
           defaultLanguage={defaultLanguage}
-          topic={editing}
-          onClose={() => setEditing(undefined)}
+          onClose={() => setCreating(false)}
         />
-      )}
+      ) : null}
 
       <ConfirmDeleteDialog
         open={pendingDelete !== null}

--- a/apps/app/src/features/knowledge/components/topic-card.tsx
+++ b/apps/app/src/features/knowledge/components/topic-card.tsx
@@ -1,23 +1,23 @@
 import type { KnowledgeTopic, KnowledgeTranslations } from "../contracts";
 
+import { routes } from "@scibly/routes";
 import { Badge } from "@scibly/ui/components/badge";
 import { Button } from "@scibly/ui/components/button";
 import { Card, CardContent } from "@scibly/ui/components/card";
+import Link from "next/link";
 
 import { TopicCardField } from "./topic-card-field";
 
 export function TopicCard({
   topic,
-  canEdit,
+  orgSlug,
   canDelete,
-  onEdit,
   onDelete,
   t,
 }: {
   topic: KnowledgeTopic;
-  canEdit: boolean;
+  orgSlug: string;
   canDelete: boolean;
-  onEdit: () => void;
   onDelete: () => void;
   t: KnowledgeTranslations;
 }) {
@@ -44,20 +44,20 @@ export function TopicCard({
               </a>
             ) : null}
           </div>
-          {canEdit || canDelete ? (
-            <div className="flex gap-2">
-              {canEdit ? (
-                <Button variant="outline" size="sm" onClick={onEdit}>
-                  {t.card.edit}
-                </Button>
-              ) : null}
-              {canDelete ? (
-                <Button variant="ghost" size="sm" onClick={onDelete}>
-                  {t.card.delete}
-                </Button>
-              ) : null}
-            </div>
-          ) : null}
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" asChild>
+              <Link
+                href={routes.app.profile.org(orgSlug).knowledge.topic(topic.id)}
+              >
+                {t.card.open}
+              </Link>
+            </Button>
+            {canDelete ? (
+              <Button variant="ghost" size="sm" onClick={onDelete}>
+                {t.card.delete}
+              </Button>
+            ) : null}
+          </div>
         </div>
 
         <dl className="grid gap-3 sm:grid-cols-2">
@@ -83,10 +83,8 @@ export function TopicCard({
           </TopicCardField>
         </dl>
 
-        {/* The count is a placeholder until the sync tickets land. */}
+        {/* pendingSuggestions stays a placeholder until suggestions land. */}
         <p className="text-ink-faint text-[12px]">
-          {t.health.lastSync}: {t.health.never}
-          {" · "}
           {t.health.pendingSuggestions.replace(
             "{count}",
             String(topic.pendingSuggestions),

--- a/apps/app/src/features/knowledge/components/topic-detail-client.tsx
+++ b/apps/app/src/features/knowledge/components/topic-detail-client.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import type { KnowledgeTranslations, TopicLanguage } from "../contracts";
+
+import { routes } from "@scibly/routes";
+import { Badge } from "@scibly/ui/components/badge";
+import { Button } from "@scibly/ui/components/button";
+import { Card, CardContent } from "@scibly/ui/components/card";
+import { ArrowLeft, RefreshCw } from "lucide-react";
+import Link from "next/link";
+import { toast } from "sonner";
+
+import { api } from "@/shared/api/trpc/client";
+
+import { KnowledgeGateNotice } from "./knowledge-gate-notice";
+import { TopicForm } from "./topic-dialog/topic-form";
+import { TopicFeed } from "./topic-feed-list";
+
+const REFETCH_WHILE_RUNNING_MS = 5_000;
+
+// A run no worker ever picked up stays QUEUED forever, so stop polling it after
+// long enough to outlast a retry.
+const GIVE_UP_ON_PENDING_MS = 15 * 60_000;
+
+export function TopicDetailClient({
+  t,
+  orgSlug,
+  topicId,
+  defaultLanguage,
+}: {
+  t: KnowledgeTranslations;
+  orgSlug: string;
+  topicId: string;
+  defaultLanguage: TopicLanguage;
+}) {
+  const utils = api.useUtils();
+  const { data, isError } = api.knowledge.get.useQuery(
+    { orgSlug, topicId },
+    {
+      refetchInterval: (query) =>
+        query.state.data?.runs.some(
+          (run) =>
+            (run.status === "QUEUED" || run.status === "RUNNING") &&
+            Date.now() - new Date(run.startedAt).getTime() <
+              GIVE_UP_ON_PENDING_MS,
+        )
+          ? REFETCH_WHILE_RUNNING_MS
+          : false,
+    },
+  );
+
+  const syncNow = api.knowledge.syncNow.useMutation({
+    onSuccess: ({ queued }) => {
+      toast.success(t.detail.syncQueued.replace("{count}", String(queued)));
+      void utils.knowledge.get.invalidate({ orgSlug, topicId });
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  if (isError) {
+    return (
+      <Card>
+        <CardContent className="p-8 text-center">
+          <p className="text-ink text-sm font-medium">{t.detail.loadFailed}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+  if (!data) return null;
+
+  const { topic } = data;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <Link
+            href={routes.app.profile.org(orgSlug).knowledge.root}
+            className="text-ink-muted hover:text-ink flex items-center gap-1 text-[13px]"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            {t.detail.back}
+          </Link>
+          <h1 className="text-ink ml-2 text-xl font-semibold">{topic.name}</h1>
+          <Badge variant="outline">{topic.language.toUpperCase()}</Badge>
+          {topic.externallyEditedAt ? (
+            <Badge variant="outline" title={t.card.externallyEditedHint}>
+              {t.card.externallyEdited}
+            </Badge>
+          ) : null}
+          {topic.documentUrl ? (
+            <a
+              href={topic.documentUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="text-ink-muted hover:text-ink text-[13px] underline underline-offset-2"
+            >
+              {t.card.openDocument}
+            </a>
+          ) : null}
+        </div>
+        {data.canSync && data.access.allowed ? (
+          <Button
+            onClick={() => syncNow.mutate({ orgSlug, topicId })}
+            disabled={syncNow.isPending}
+          >
+            <RefreshCw className="h-4 w-4" />
+            {syncNow.isPending ? t.detail.syncing : t.detail.syncNow}
+          </Button>
+        ) : null}
+      </div>
+
+      <KnowledgeGateNotice t={t} access={data.access} />
+
+      <TopicFeed t={t} runs={data.runs} bundles={data.bundles} />
+
+      {data.canManage && data.access.allowed ? (
+        <Card>
+          <CardContent className="flex flex-col gap-4 p-5">
+            <h2 className="text-ink text-base font-semibold">
+              {t.detail.settings}
+            </h2>
+            <TopicForm
+              t={t}
+              orgSlug={orgSlug}
+              orgId={data.organizationId}
+              defaultLanguage={defaultLanguage}
+              topic={topic}
+            />
+          </CardContent>
+        </Card>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/app/src/features/knowledge/components/topic-dialog/contracts.ts
+++ b/apps/app/src/features/knowledge/components/topic-dialog/contracts.ts
@@ -4,5 +4,3 @@ export const toggle = (values: string[], value: string) =>
   values.includes(value)
     ? values.filter((each) => each !== value)
     : [...values, value];
-
-export const FOLDER_SUFFIX = "/**";

--- a/apps/app/src/features/knowledge/components/topic-dialog/index.tsx
+++ b/apps/app/src/features/knowledge/components/topic-dialog/index.tsx
@@ -1,94 +1,30 @@
 "use client";
 
-import type {
-  KnowledgeTopic,
-  KnowledgeTranslations,
-  TopicLanguage,
-} from "../../contracts";
-import type { Option } from "./contracts";
+import type { KnowledgeTranslations, TopicLanguage } from "../../contracts";
 
-import { Button } from "@scibly/ui/components/button";
 import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@scibly/ui/components/dialog";
-import { Input } from "@scibly/ui/components/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@scibly/ui/components/select";
-import { AlertCircle } from "lucide-react";
-import { Controller } from "react-hook-form";
 
-import { api } from "@/shared/api/trpc/client";
-
-import { MAX_TOPIC_REPOSITORIES, TOPIC_LANGUAGES } from "../../contracts";
-import { Chips } from "./chips";
-import { toggle } from "./contracts";
-import { FieldLabel } from "./field-label";
-import { MultiSelect } from "./multi-select";
-import { RepoScopeRow } from "./repo-scope-row";
-import { useTopicForm } from "./use-topic-form";
+import { TopicForm } from "./topic-form";
 
 export function TopicDialog({
   t,
   orgSlug,
   orgId,
   defaultLanguage,
-  topic,
   onClose,
 }: {
   t: KnowledgeTranslations;
   orgSlug: string;
   orgId: string;
   defaultLanguage: TopicLanguage;
-  topic: KnowledgeTopic | null;
   onClose: () => void;
 }) {
-  const {
-    control,
-    register,
-    setValue,
-    setError,
-    clearErrors,
-    repositories,
-    maintainerMemberIds,
-    refusal,
-    submit,
-    isPending,
-    isDirty,
-  } = useTopicForm({ t, orgSlug, defaultLanguage, topic, onClose });
-
-  const grants = api.integration.listGrants.useQuery({
-    orgSlug,
-    provider: "GITHUB",
-  });
-  const members = api.organization.listMembers.useQuery({
-    organizationId: orgId,
-  });
-
-  const repositoryOptions: Option[] = (grants.data?.grants ?? []).map(
-    (grant) => ({ id: grant.id, label: grant.name }),
-  );
-  const memberOptions: Option[] = (members.data ?? []).map((member) => ({
-    id: member.id,
-    label: member.user.name || member.user.email,
-  }));
-
-  // Only a complete listing may call a row stale: one that stopped at its page budget has not seen every repository.
-  const listedEverything =
-    grants.data !== undefined &&
-    grants.data.grants.length >= grants.data.totalCount;
-  const isStale = (id: string) =>
-    listedEverything && !repositoryOptions.some((option) => option.id === id);
-
   return (
     <Dialog open onOpenChange={(open) => !open && onClose()}>
       <DialogContent
@@ -96,189 +32,18 @@ export function TopicDialog({
         onInteractOutside={(event) => event.preventDefault()}
       >
         <DialogHeader>
-          <DialogTitle>
-            {topic ? t.form.editTitle : t.form.createTitle}
-          </DialogTitle>
+          <DialogTitle>{t.form.createTitle}</DialogTitle>
           <DialogDescription>{t.form.description}</DialogDescription>
         </DialogHeader>
-
-        <div className="flex flex-col gap-5">
-          <div className="grid gap-4 sm:grid-cols-[1fr_12rem]">
-            <div className="flex flex-col gap-1.5">
-              <FieldLabel htmlFor="topic-name">{t.form.name}</FieldLabel>
-              <Input
-                id="topic-name"
-                maxLength={120}
-                placeholder={t.form.namePlaceholder}
-                {...register("name")}
-              />
-            </div>
-
-            <div className="flex flex-col gap-1.5">
-              <FieldLabel htmlFor="topic-language">
-                {t.form.language}
-              </FieldLabel>
-              <Controller
-                control={control}
-                name="language"
-                render={({ field }) => (
-                  <Select value={field.value} onValueChange={field.onChange}>
-                    <SelectTrigger id="topic-language" className="w-full">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {TOPIC_LANGUAGES.map((code) => (
-                        <SelectItem key={code} value={code}>
-                          {code === "de"
-                            ? t.form.languageDe
-                            : t.form.languageEn}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-              />
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <FieldLabel>{t.form.repositories}</FieldLabel>
-            <p className="text-ink-faint text-[12px]">
-              {t.form.repositoriesHint}
-            </p>
-            <MultiSelect
-              t={t}
-              options={repositoryOptions}
-              selected={repositories.map((repo) => repo.id)}
-              onToggle={(id) => {
-                if (repositories.some((repo) => repo.id === id)) {
-                  clearErrors("repositories");
-                  return setValue(
-                    "repositories",
-                    repositories.filter((repo) => repo.id !== id),
-                  );
-                }
-                if (repositories.length >= MAX_TOPIC_REPOSITORIES) {
-                  return setError("repositories", {
-                    type: "manual",
-                    message: t.form.repositoriesMax.replace(
-                      "{max}",
-                      String(MAX_TOPIC_REPOSITORIES),
-                    ),
-                  });
-                }
-                clearErrors("repositories");
-                setValue("repositories", [
-                  ...repositories,
-                  { id, pathGlobs: [] },
-                ]);
-              }}
-              placeholder={t.form.repositoriesSelect}
-              empty={
-                grants.isPending
-                  ? t.form.repositoriesLoading
-                  : grants.isError
-                    ? t.form.repositoriesUnavailable
-                    : t.form.repositoriesEmpty
-              }
-            />
-            {repositories.length === 0 ? null : (
-              <div className="border-edge divide-edge divide-y rounded-xl border">
-                {repositories.map((repo) => (
-                  <RepoScopeRow
-                    key={repo.id}
-                    t={t}
-                    orgSlug={orgSlug}
-                    id={repo.id}
-                    label={
-                      repositoryOptions.find((option) => option.id === repo.id)
-                        ?.label ?? repo.id
-                    }
-                    stale={isStale(repo.id)}
-                    pathGlobs={repo.pathGlobs}
-                    onGlobs={(globs) =>
-                      setValue(
-                        "repositories",
-                        repositories.map((each) =>
-                          each.id === repo.id
-                            ? { ...each, pathGlobs: globs }
-                            : each,
-                        ),
-                      )
-                    }
-                    onRemove={() =>
-                      setValue(
-                        "repositories",
-                        repositories.filter((each) => each.id !== repo.id),
-                      )
-                    }
-                  />
-                ))}
-              </div>
-            )}
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <FieldLabel optional={t.form.optional}>
-              {t.form.maintainers}
-            </FieldLabel>
-            <p className="text-ink-faint text-[12px]">
-              {t.form.maintainersHint}
-            </p>
-            <MultiSelect
-              t={t}
-              options={memberOptions}
-              selected={maintainerMemberIds}
-              onToggle={(id) =>
-                setValue("maintainerMemberIds", toggle(maintainerMemberIds, id))
-              }
-              placeholder={t.form.maintainersSelect}
-              empty={
-                members.isPending
-                  ? t.form.maintainersLoading
-                  : members.isError
-                    ? t.form.maintainersUnavailable
-                    : t.form.maintainersEmpty
-              }
-            />
-            <Chips
-              t={t}
-              values={maintainerMemberIds.map((id) => ({
-                id,
-                label:
-                  memberOptions.find((option) => option.id === id)?.label ?? id,
-              }))}
-              onRemove={(id) =>
-                setValue("maintainerMemberIds", toggle(maintainerMemberIds, id))
-              }
-            />
-          </div>
-
-          {refusal === null ? null : (
-            <p
-              role="alert"
-              className="text-destructive flex items-start gap-2 rounded-lg border border-red-300/70 bg-red-50/70 px-3 py-2 text-[13px]"
-            >
-              <AlertCircle
-                className="mt-0.5 h-4 w-4 shrink-0"
-                aria-hidden="true"
-              />
-              {refusal}
-            </p>
-          )}
-        </div>
-
-        <DialogFooter>
-          <Button variant="outline" onClick={onClose} disabled={isPending}>
-            {t.form.cancel}
-          </Button>
-          <Button
-            onClick={() => void submit()}
-            disabled={isPending || !isDirty}
-          >
-            {isPending ? t.form.saving : t.form.save}
-          </Button>
-        </DialogFooter>
+        <TopicForm
+          t={t}
+          orgSlug={orgSlug}
+          orgId={orgId}
+          defaultLanguage={defaultLanguage}
+          topic={null}
+          onCancel={onClose}
+          onSaved={onClose}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/apps/app/src/features/knowledge/components/topic-dialog/repo-scope-row.tsx
+++ b/apps/app/src/features/knowledge/components/topic-dialog/repo-scope-row.tsx
@@ -15,8 +15,10 @@ import { api } from "@/shared/api/trpc/client";
 
 import { isValidPathGlob, MAX_TOPIC_PATH_GLOBS } from "../../contracts";
 import { Chips } from "./chips";
-import { FOLDER_SUFFIX, toggle } from "./contracts";
+import { toggle } from "./contracts";
 import { Picker } from "./picker";
+
+const FOLDER_SUFFIX = "/**";
 
 export function RepoScopeRow({
   t,

--- a/apps/app/src/features/knowledge/components/topic-dialog/topic-form.tsx
+++ b/apps/app/src/features/knowledge/components/topic-dialog/topic-form.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import type {
+  KnowledgeTopic,
+  KnowledgeTranslations,
+  TopicLanguage,
+} from "../../contracts";
+import type { Option } from "./contracts";
+
+import { Button } from "@scibly/ui/components/button";
+import { Input } from "@scibly/ui/components/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@scibly/ui/components/select";
+import { AlertCircle } from "lucide-react";
+import { Controller } from "react-hook-form";
+
+import { api } from "@/shared/api/trpc/client";
+
+import { MAX_TOPIC_REPOSITORIES, TOPIC_LANGUAGES } from "../../contracts";
+import { Chips } from "./chips";
+import { toggle } from "./contracts";
+import { FieldLabel } from "./field-label";
+import { MultiSelect } from "./multi-select";
+import { RepoScopeRow } from "./repo-scope-row";
+import { useTopicForm } from "./use-topic-form";
+
+export function TopicForm({
+  t,
+  orgSlug,
+  orgId,
+  defaultLanguage,
+  topic,
+  onCancel,
+  onSaved,
+}: {
+  t: KnowledgeTranslations;
+  orgSlug: string;
+  orgId: string;
+  defaultLanguage: TopicLanguage;
+  topic: KnowledgeTopic | null;
+  onCancel?: () => void;
+  onSaved?: () => void;
+}) {
+  const {
+    control,
+    register,
+    setValue,
+    setError,
+    clearErrors,
+    repositories,
+    maintainerMemberIds,
+    refusal,
+    submit,
+    isPending,
+    isDirty,
+  } = useTopicForm({ t, orgSlug, defaultLanguage, topic, onSaved });
+
+  const grants = api.integration.listGrants.useQuery({
+    orgSlug,
+    provider: "GITHUB",
+  });
+  const members = api.organization.listMembers.useQuery({
+    organizationId: orgId,
+  });
+
+  const repositoryOptions: Option[] = (grants.data?.grants ?? []).map(
+    (grant) => ({ id: grant.id, label: grant.name }),
+  );
+  const memberOptions: Option[] = (members.data ?? []).map((member) => ({
+    id: member.id,
+    label: member.user.name || member.user.email,
+  }));
+
+  // Only a complete listing may call a row stale: one that stopped at its page budget has not seen every repository.
+  const listedEverything =
+    grants.data !== undefined &&
+    grants.data.grants.length >= grants.data.totalCount;
+  const isStale = (id: string) =>
+    listedEverything && !repositoryOptions.some((option) => option.id === id);
+
+  return (
+    <>
+      <div className="flex flex-col gap-5">
+        <div className="grid gap-4 sm:grid-cols-[1fr_12rem]">
+          <div className="flex flex-col gap-1.5">
+            <FieldLabel htmlFor="topic-name">{t.form.name}</FieldLabel>
+            <Input
+              id="topic-name"
+              maxLength={120}
+              placeholder={t.form.namePlaceholder}
+              {...register("name")}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <FieldLabel htmlFor="topic-language">{t.form.language}</FieldLabel>
+            <Controller
+              control={control}
+              name="language"
+              render={({ field }) => (
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <SelectTrigger id="topic-language" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {TOPIC_LANGUAGES.map((code) => (
+                      <SelectItem key={code} value={code}>
+                        {code === "de" ? t.form.languageDe : t.form.languageEn}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <FieldLabel>{t.form.repositories}</FieldLabel>
+          <p className="text-ink-faint text-[12px]">
+            {t.form.repositoriesHint}
+          </p>
+          <MultiSelect
+            t={t}
+            options={repositoryOptions}
+            selected={repositories.map((repo) => repo.id)}
+            onToggle={(id) => {
+              if (repositories.some((repo) => repo.id === id)) {
+                clearErrors("repositories");
+                return setValue(
+                  "repositories",
+                  repositories.filter((repo) => repo.id !== id),
+                );
+              }
+              if (repositories.length >= MAX_TOPIC_REPOSITORIES) {
+                return setError("repositories", {
+                  type: "manual",
+                  message: t.form.repositoriesMax.replace(
+                    "{max}",
+                    String(MAX_TOPIC_REPOSITORIES),
+                  ),
+                });
+              }
+              clearErrors("repositories");
+              setValue("repositories", [
+                ...repositories,
+                { id, pathGlobs: [] },
+              ]);
+            }}
+            placeholder={t.form.repositoriesSelect}
+            empty={
+              grants.isPending
+                ? t.form.repositoriesLoading
+                : grants.isError
+                  ? t.form.repositoriesUnavailable
+                  : t.form.repositoriesEmpty
+            }
+          />
+          {repositories.length === 0 ? null : (
+            <div className="border-edge divide-edge divide-y rounded-xl border">
+              {repositories.map((repo) => (
+                <RepoScopeRow
+                  key={repo.id}
+                  t={t}
+                  orgSlug={orgSlug}
+                  id={repo.id}
+                  label={
+                    repositoryOptions.find((option) => option.id === repo.id)
+                      ?.label ?? repo.id
+                  }
+                  stale={isStale(repo.id)}
+                  pathGlobs={repo.pathGlobs}
+                  onGlobs={(globs) =>
+                    setValue(
+                      "repositories",
+                      repositories.map((each) =>
+                        each.id === repo.id
+                          ? { ...each, pathGlobs: globs }
+                          : each,
+                      ),
+                    )
+                  }
+                  onRemove={() =>
+                    setValue(
+                      "repositories",
+                      repositories.filter((each) => each.id !== repo.id),
+                    )
+                  }
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <FieldLabel optional={t.form.optional}>
+            {t.form.maintainers}
+          </FieldLabel>
+          <p className="text-ink-faint text-[12px]">{t.form.maintainersHint}</p>
+          <MultiSelect
+            t={t}
+            options={memberOptions}
+            selected={maintainerMemberIds}
+            onToggle={(id) =>
+              setValue("maintainerMemberIds", toggle(maintainerMemberIds, id))
+            }
+            placeholder={t.form.maintainersSelect}
+            empty={
+              members.isPending
+                ? t.form.maintainersLoading
+                : members.isError
+                  ? t.form.maintainersUnavailable
+                  : t.form.maintainersEmpty
+            }
+          />
+          <Chips
+            t={t}
+            values={maintainerMemberIds.map((id) => ({
+              id,
+              label:
+                memberOptions.find((option) => option.id === id)?.label ?? id,
+            }))}
+            onRemove={(id) =>
+              setValue("maintainerMemberIds", toggle(maintainerMemberIds, id))
+            }
+          />
+        </div>
+
+        {refusal === null ? null : (
+          <p
+            role="alert"
+            className="text-destructive flex items-start gap-2 rounded-lg border border-red-300/70 bg-red-50/70 px-3 py-2 text-[13px]"
+          >
+            <AlertCircle
+              className="mt-0.5 h-4 w-4 shrink-0"
+              aria-hidden="true"
+            />
+            {refusal}
+          </p>
+        )}
+      </div>
+
+      <div className="flex justify-end gap-2 pt-4">
+        {onCancel ? (
+          <Button variant="outline" onClick={onCancel} disabled={isPending}>
+            {t.form.cancel}
+          </Button>
+        ) : null}
+        <Button onClick={() => void submit()} disabled={isPending || !isDirty}>
+          {isPending ? t.form.saving : t.form.save}
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/apps/app/src/features/knowledge/components/topic-dialog/use-topic-form.ts
+++ b/apps/app/src/features/knowledge/components/topic-dialog/use-topic-form.ts
@@ -27,13 +27,13 @@ export function useTopicForm({
   orgSlug,
   defaultLanguage,
   topic,
-  onClose,
+  onSaved,
 }: {
   t: KnowledgeTranslations;
   orgSlug: string;
   defaultLanguage: TopicLanguage;
   topic: KnowledgeTopic | null;
-  onClose: () => void;
+  onSaved?: () => void;
 }) {
   const utils = api.useUtils();
   const {
@@ -72,27 +72,41 @@ export function useTopicForm({
     maintainerMemberIds,
     language,
   });
-  const [saved] = useState(fingerprint);
+  const [saved, setSaved] = useState(fingerprint);
 
-  const settle = () => {
+  // Read off the mutation's own variables: an edit made while the save was in flight must stay dirty.
+  const settle = (fields: TopicFormInput) => {
+    setSaved(
+      topicFingerprint({
+        name: fields.name,
+        repositories: fields.repositories.map(({ id, pathGlobs }) => ({
+          id,
+          pathGlobs: pathGlobs ?? [],
+        })),
+        maintainerMemberIds: fields.maintainerMemberIds ?? [],
+        language: fields.language,
+      }),
+    );
     void utils.knowledge.list.invalidate({ orgSlug });
-    onClose();
+    if (topic)
+      void utils.knowledge.get.invalidate({ orgSlug, topicId: topic.id });
+    onSaved?.();
   };
   const onError = (failure: { message: string }) =>
     setError("root", { message: failure.message });
 
   const create = api.knowledge.create.useMutation({
-    onSuccess: () => {
+    onSuccess: (_created, fields) => {
       toast.success(t.form.created);
-      settle();
+      settle(fields);
     },
     onError,
   });
   const update = api.knowledge.update.useMutation({
-    onSuccess: (saved) => {
+    onSuccess: (saved, fields) => {
       if (saved.externallyEditedAt) toast.warning(t.form.updatedDocumentLeft);
       else toast.success(t.form.updated);
-      settle();
+      settle(fields);
     },
     onError,
   });
@@ -102,7 +116,6 @@ export function useTopicForm({
     else create.mutate({ ...fields, orgSlug });
   });
 
-  // Manual errors are already translated; the schema's are mapped by what they can only mean.
   const repositoryRefusal =
     errors.repositories?.type === "manual"
       ? (errors.repositories.message ?? null)

--- a/apps/app/src/features/knowledge/components/topic-feed-list.tsx
+++ b/apps/app/src/features/knowledge/components/topic-feed-list.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import type { KnowledgeTranslations } from "../contracts";
+
+import { useLocale } from "@scibly/i18n/react";
+import { Badge } from "@scibly/ui/components/badge";
+import { Card, CardContent } from "@scibly/ui/components/card";
+
+import { type RouterOutputs } from "@/shared/api/trpc/contracts";
+
+type TopicView = RouterOutputs["knowledge"]["get"];
+
+export function TopicFeed({
+  t,
+  runs,
+  bundles,
+}: {
+  t: KnowledgeTranslations;
+  runs: TopicView["runs"];
+  bundles: TopicView["bundles"];
+}) {
+  // The route's locale, not the browser's: the server rendered this list first.
+  const locale = useLocale();
+  const statusLabels = {
+    QUEUED: t.feed.queued,
+    RUNNING: t.feed.running,
+    SUCCEEDED: t.feed.succeeded,
+    FAILED: t.feed.failed,
+  } satisfies Record<TopicView["runs"][number]["status"], string>;
+
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-5 p-5">
+        <h2 className="text-ink text-base font-semibold">{t.feed.title}</h2>
+
+        {runs.length === 0 ? (
+          <p className="text-ink-muted text-[13px]">{t.feed.empty}</p>
+        ) : (
+          <ul className="divide-edge divide-y text-[13px]">
+            {runs.map((run) => (
+              <li key={run.id} className="flex flex-wrap gap-2 py-2">
+                <Badge variant="outline">{statusLabels[run.status]}</Badge>
+                <span className="text-ink truncate">{run.repository}</span>
+                <span className="text-ink-muted">
+                  {t.feed.counts
+                    .replace("{collected}", String(run.collected))
+                    .replace("{discarded}", String(run.discarded))}
+                  {run.capped ? ` · ${t.feed.capped}` : ""}
+                </span>
+                <time className="text-ink-faint ml-auto">
+                  {new Date(run.startedAt).toLocaleString(locale)}
+                </time>
+                {run.failureReason ? (
+                  <p className="text-destructive w-full">{run.failureReason}</p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="flex flex-col gap-2">
+          <h3 className="text-ink text-sm font-medium">{t.feed.bundles}</h3>
+          {bundles.length === 0 ? (
+            <p className="text-ink-muted text-[13px]">{t.feed.noBundles}</p>
+          ) : (
+            <ul className="flex flex-col gap-1 text-[13px]">
+              {bundles.map((bundle) => (
+                <li key={bundle.id} className="flex gap-2">
+                  <a
+                    href={bundle.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-ink hover:text-ink-muted truncate underline underline-offset-2"
+                  >
+                    #{bundle.number} {bundle.title}
+                  </a>
+                  <span className="text-ink-faint shrink-0">
+                    {bundle.repository}
+                    {bundle.truncated ? ` · ${t.feed.truncated}` : ""}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/app/src/features/knowledge/components/topic-form.test.tsx
+++ b/apps/app/src/features/knowledge/components/topic-form.test.tsx
@@ -11,7 +11,7 @@ import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import knowledgeEn from "../i18n/knowledge.i18n.en.json";
-import { TopicDialog } from "./topic-dialog";
+import { TopicForm } from "./topic-dialog/topic-form";
 
 const listFolders = vi.hoisted(() => vi.fn());
 const listGrants = vi.hoisted(() => vi.fn());
@@ -22,7 +22,9 @@ const invalidate = vi.hoisted(() => vi.fn());
 
 vi.mock("@/shared/api/trpc/client", () => ({
   api: {
-    useUtils: () => ({ knowledge: { list: { invalidate } } }),
+    useUtils: () => ({
+      knowledge: { list: { invalidate }, get: { invalidate } },
+    }),
     knowledge: {
       listFolders: { useQuery: listFolders },
       create: { useMutation: createMutation },
@@ -39,12 +41,14 @@ vi.mock("sonner", () => ({
 const t = knowledgeEn.knowledge;
 
 type MutationOptions = {
-  onSuccess: (saved: { externallyEditedAt: Date | null }) => void;
+  onSuccess: (
+    saved: { externallyEditedAt: Date | null },
+    fields: unknown,
+  ) => void;
   onError: (failure: { message: string }) => void;
 };
 
 const mutate = vi.fn();
-// The dialog hands its callbacks to `useMutation`; holding on to them is how a test plays the server's answer back.
 let lastUpdateOptions: MutationOptions;
 
 const topic = {
@@ -88,13 +92,13 @@ beforeEach(() => {
 
 const open = (edited: KnowledgeTopic | null = topic) =>
   render(
-    <TopicDialog
+    <TopicForm
       t={t}
       orgSlug="acme"
       orgId="org-1"
       defaultLanguage="en"
       topic={edited}
-      onClose={() => {}}
+      onSaved={() => {}}
     />,
   );
 
@@ -268,7 +272,12 @@ describe("what the dialog says a save did", () => {
   it("says the topic was updated when the document went with it", async () => {
     await saveTopic();
 
-    act(() => lastUpdateOptions.onSuccess({ externallyEditedAt: null }));
+    act(() =>
+      lastUpdateOptions.onSuccess(
+        { externallyEditedAt: null },
+        mutate.mock.calls.at(-1)![0],
+      ),
+    );
 
     expect(toast.success).toHaveBeenCalledWith(t.form.updated);
     expect(toast.warning).not.toHaveBeenCalled();
@@ -277,7 +286,12 @@ describe("what the dialog says a save did", () => {
   it("says the page was left alone when someone else had edited it", async () => {
     await saveTopic();
 
-    act(() => lastUpdateOptions.onSuccess({ externallyEditedAt: new Date() }));
+    act(() =>
+      lastUpdateOptions.onSuccess(
+        { externallyEditedAt: new Date() },
+        mutate.mock.calls.at(-1)![0],
+      ),
+    );
 
     expect(toast.warning).toHaveBeenCalledWith(t.form.updatedDocumentLeft);
     expect(toast.success).not.toHaveBeenCalled();

--- a/apps/app/src/features/knowledge/contracts.ts
+++ b/apps/app/src/features/knowledge/contracts.ts
@@ -13,12 +13,16 @@ export type TopicLanguage = (typeof TOPIC_LANGUAGES)[number];
 export const MAX_TOPIC_REPOSITORIES = 50;
 export const MAX_TOPIC_PATH_GLOBS = 20;
 
+// Braces and long wildcard chains are refused because `matchesGlob` backtracks,
+// and topic globs run against every file path of every bundle on a polled path.
 export const isValidPathGlob = (glob: string) =>
   glob.length > 0 &&
   glob.length <= 200 &&
   !glob.startsWith("/") &&
   !glob.includes("..") &&
-  !glob.includes("\\");
+  !glob.includes("\\") &&
+  !/[{}[\]?]/.test(glob) &&
+  (glob.match(/\*/g)?.length ?? 0) <= 6;
 
 export type { TopicRepositoryInput } from "./api/knowledge.schema";
 export type { TopicRepository } from "./server/topic-repositories";

--- a/apps/app/src/features/knowledge/i18n/knowledge.i18n.de.json
+++ b/apps/app/src/features/knowledge/i18n/knowledge.i18n.de.json
@@ -15,19 +15,17 @@
       "fallbackPlan": "einem bezahlten Tarif"
     },
     "health": {
-      "lastSync": "Letzter Abgleich",
-      "never": "Nie",
       "pendingSuggestions": "{count} offene Vorschläge"
     },
     "card": {
       "repositories": "Repositories",
       "maintainers": "Verantwortliche",
       "noMaintainers": "Keine",
-      "edit": "Bearbeiten",
       "delete": "Löschen",
       "openDocument": "Dokument öffnen",
       "externallyEdited": "In Notion bearbeitet",
-      "externallyEditedHint": "Jemand hat diese Seite in Notion geändert. Scibly überschreibt sie nicht."
+      "externallyEditedHint": "Jemand hat diese Seite in Notion geändert. Scibly überschreibt sie nicht.",
+      "open": "Öffnen"
     },
     "destination": {
       "title": "Wo Dokumente liegen",
@@ -48,7 +46,6 @@
     },
     "form": {
       "createTitle": "Neues Thema",
-      "editTitle": "Thema bearbeiten",
       "description": "Worum es im Dokument geht und welchen Repositories es folgt.",
       "optional": "optional",
       "name": "Name",
@@ -93,11 +90,32 @@
     },
     "deleteDialog": {
       "title": "Thema löschen?",
-      "description": "„{name}“ und alles, was es gesammelt hat, wird entfernt.",
+      "description": "„{name}“ wird entfernt. Bereits gesammelte Pull Requests bleiben bei der Organisation, und die Notion-Seite bleibt unberührt.",
       "confirm": "Löschen",
       "cancel": "Abbrechen",
       "deleted": "Thema gelöscht"
     },
-    "loadFailed": "Themen konnten nicht geladen werden. Lade die Seite neu."
+    "loadFailed": "Themen konnten nicht geladen werden. Lade die Seite neu.",
+    "detail": {
+      "back": "Alle Themen",
+      "syncNow": "Jetzt synchronisieren",
+      "syncing": "Wird synchronisiert…",
+      "syncQueued": "Synchronisierung für {count} Repositories eingeplant",
+      "settings": "Einstellungen",
+      "loadFailed": "Dieses Thema konnte nicht geladen werden. Lade die Seite neu."
+    },
+    "feed": {
+      "title": "Aktivität",
+      "empty": "Es wurde noch nichts gesammelt. Starte eine Synchronisierung.",
+      "counts": "{collected} gesammelt · {discarded} verworfen",
+      "capped": "am Budget gestoppt",
+      "queued": "Eingeplant",
+      "running": "Läuft",
+      "succeeded": "Fertig",
+      "failed": "Fehlgeschlagen",
+      "bundles": "Gesammelte Pull Requests",
+      "noBundles": "Noch keine Pull Requests gesammelt. Das Sammeln beginnt mit der ersten Synchronisierung; ab dann zusammengeführte Pull Requests erscheinen hier.",
+      "truncated": "gekürzt"
+    }
   }
 }

--- a/apps/app/src/features/knowledge/i18n/knowledge.i18n.en.json
+++ b/apps/app/src/features/knowledge/i18n/knowledge.i18n.en.json
@@ -15,19 +15,17 @@
       "fallbackPlan": "a paid plan"
     },
     "health": {
-      "lastSync": "Last sync",
-      "never": "Never",
       "pendingSuggestions": "{count} pending suggestions"
     },
     "card": {
       "repositories": "Repositories",
       "maintainers": "Maintainers",
       "noMaintainers": "None",
-      "edit": "Edit",
       "delete": "Delete",
       "openDocument": "Open document",
       "externallyEdited": "Edited in Notion",
-      "externallyEditedHint": "Someone changed this page in Notion. Scibly will not overwrite it."
+      "externallyEditedHint": "Someone changed this page in Notion. Scibly will not overwrite it.",
+      "open": "Open"
     },
     "destination": {
       "title": "Where documents live",
@@ -48,7 +46,6 @@
     },
     "form": {
       "createTitle": "New topic",
-      "editTitle": "Edit topic",
       "description": "What the document is about, and which repositories it follows.",
       "optional": "optional",
       "name": "Name",
@@ -93,11 +90,32 @@
     },
     "deleteDialog": {
       "title": "Delete topic?",
-      "description": "\"{name}\" and everything it has gathered will be removed.",
+      "description": "\"{name}\" will be removed. The pull requests already collected stay with the organization, and its Notion page is left alone.",
       "confirm": "Delete",
       "cancel": "Cancel",
       "deleted": "Topic deleted"
     },
-    "loadFailed": "Topics could not be loaded. Reload the page to try again."
+    "loadFailed": "Topics could not be loaded. Reload the page to try again.",
+    "detail": {
+      "back": "All topics",
+      "syncNow": "Sync now",
+      "syncing": "Syncing…",
+      "syncQueued": "Sync queued for {count} repositories",
+      "settings": "Settings",
+      "loadFailed": "This topic could not be loaded. Reload the page to try again."
+    },
+    "feed": {
+      "title": "Activity",
+      "empty": "Nothing has been collected yet. Run a sync to start.",
+      "counts": "{collected} collected · {discarded} discarded",
+      "capped": "stopped at its budget",
+      "queued": "Queued",
+      "running": "Running",
+      "succeeded": "Done",
+      "failed": "Failed",
+      "bundles": "Collected pull requests",
+      "noBundles": "No pull requests collected yet. Collection starts at the first sync, so pull requests merged from then on appear here.",
+      "truncated": "shortened"
+    }
   }
 }

--- a/apps/app/src/features/knowledge/server.ts
+++ b/apps/app/src/features/knowledge/server.ts
@@ -1,3 +1,7 @@
 import "server-only";
 
 export { knowledgeRouter } from "./api/knowledge.router";
+export {
+  knowledgeCollect,
+  knowledgeCollectionSync,
+} from "./server/collect/collection-sync";

--- a/apps/app/src/features/knowledge/server/collect/bundle.test.ts
+++ b/apps/app/src/features/knowledge/server/collect/bundle.test.ts
@@ -1,0 +1,95 @@
+import type { PullRequestDetail } from "@/features/integrations/server";
+
+import { describe, expect, it } from "vitest";
+
+import { estimateTokens } from "@/shared/ai/token-estimate";
+
+import { buildBundleContent, BUNDLE_LIMITS } from "./bundle";
+
+const MERGED = new Date("2026-08-02T00:00:00Z");
+
+const comment = (body: string) => ({
+  author: "ada",
+  body,
+  url: "https://github.com/acme/api/pull/7#discussion",
+  diffHunk: null,
+});
+
+const detail = (over: Partial<PullRequestDetail>): PullRequestDetail => ({
+  externalId: "PR_1",
+  number: 7,
+  title: "Give the scheduler a per-account lock",
+  body: "",
+  url: "https://github.com/acme/api/pull/7",
+  labels: ["design"],
+  filePaths: ["src/scheduler.ts"],
+  filesTruncated: false,
+  linkedIssues: [],
+  comments: [],
+  threads: [],
+  mergedAt: MERGED,
+  updatedAt: MERGED,
+  ...over,
+});
+
+const tokensOf = (content: unknown) => estimateTokens(JSON.stringify(content));
+
+describe("a bundle is capped at the size it claims", () => {
+  it("leaves a pull request that already fits alone", () => {
+    const { content, truncated } = buildBundleContent(
+      detail({
+        body: "Why a global lock is the wrong shape here.",
+        comments: [comment("Agreed, per-account is the boundary.")],
+      }),
+    );
+
+    expect(truncated).toBe(false);
+    expect(content.body).toBe("Why a global lock is the wrong shape here.");
+    expect(content.comments).toHaveLength(1);
+  });
+
+  it("cuts a description that would blow the cap on its own", () => {
+    const { content, truncated } = buildBundleContent(
+      detail({ body: "a".repeat(65_000) }),
+    );
+
+    expect(tokensOf(content)).toBeLessThanOrEqual(BUNDLE_LIMITS.maxTokens);
+    expect(truncated).toBe(true);
+    expect(content.body.endsWith("…")).toBe(true);
+  });
+
+  it("drops comments once the description alone is not enough", () => {
+    const { content, truncated } = buildBundleContent(
+      detail({
+        comments: Array.from({ length: 40 }, () => comment("b".repeat(2_000))),
+      }),
+    );
+
+    expect(tokensOf(content)).toBeLessThanOrEqual(BUNDLE_LIMITS.maxTokens);
+    expect(truncated).toBe(true);
+    expect(content.comments.length).toBeLessThan(40);
+  });
+
+  it("spends the shallow threads before the deep one", () => {
+    const deep = {
+      path: "src/scheduler.ts",
+      isResolved: false,
+      comments: Array.from({ length: 6 }, () => comment("c".repeat(400))),
+    };
+    const shallow = Array.from({ length: 20 }, () => ({
+      path: "src/queue.ts",
+      isResolved: true,
+      comments: [comment("d".repeat(2_000))],
+    }));
+
+    const { content } = buildBundleContent(
+      detail({ threads: [...shallow, deep] }),
+    );
+
+    expect(tokensOf(content)).toBeLessThanOrEqual(BUNDLE_LIMITS.maxTokens);
+    expect(content.threads.length).toBeLessThan(shallow.length);
+    expect(content.threads.some((thread) => thread.comments.length === 6)).toBe(
+      true,
+    );
+  });
+});

--- a/apps/app/src/features/knowledge/server/collect/bundle.ts
+++ b/apps/app/src/features/knowledge/server/collect/bundle.ts
@@ -1,0 +1,105 @@
+import type { PullRequestDetail } from "@/features/integrations/server";
+
+import { CHARS_PER_TOKEN, estimateTokens } from "@/shared/ai/token-estimate";
+import { sanitizeSourceTextForIndexing } from "@/shared/content/sources/sanitize-source-text";
+
+/** Per-bundle cap, not per-prompt: a model reads several bundles alongside each other. */
+export const BUNDLE_LIMITS = {
+  maxTokens: 6_000,
+  diffHunkLines: 20,
+} as const;
+
+type BundleComment = {
+  author: string | null;
+  body: string;
+  url: string;
+  diffHunk: string | null;
+};
+
+export type BundleContent = {
+  title: string;
+  body: string;
+  url: string;
+  labels: string[];
+  filePaths: string[];
+  linkedIssues: { number: number; title: string; url: string }[];
+  comments: BundleComment[];
+  threads: {
+    path: string | null;
+    isResolved: boolean;
+    comments: BundleComment[];
+  }[];
+};
+
+const trimHunk = (hunk: string | null) => {
+  if (!hunk) return null;
+  const lines = hunk.split("\n");
+  return lines.length <= BUNDLE_LIMITS.diffHunkLines
+    ? hunk
+    : `${lines.slice(0, BUNDLE_LIMITS.diffHunkLines).join("\n")}\n…`;
+};
+
+const cleanComment = (source: BundleComment) => ({
+  author: source.author,
+  body: sanitizeSourceTextForIndexing(source.body),
+  url: source.url,
+  diffHunk: trimHunk(source.diffHunk),
+});
+
+const overshootChars = (content: BundleContent) =>
+  (estimateTokens(JSON.stringify(content)) - BUNDLE_LIMITS.maxTokens) *
+  CHARS_PER_TOKEN;
+
+const cutTo = (text: string, chars: number) =>
+  text.length <= chars ? text : `${text.slice(0, Math.max(chars - 1, 0))}…`;
+
+/**
+ * Cut order when over the cap: body first, then shallowest threads, then
+ * comments — the deep back-and-forth is the material being mined.
+ */
+export function buildBundleContent(detail: PullRequestDetail) {
+  const threads = detail.threads.map((thread) => ({
+    path: thread.path,
+    isResolved: thread.isResolved,
+    comments: thread.comments.map(cleanComment),
+  }));
+  const content: BundleContent = {
+    title: sanitizeSourceTextForIndexing(detail.title),
+    body: sanitizeSourceTextForIndexing(detail.body),
+    url: detail.url,
+    labels: [...detail.labels],
+    filePaths: [...detail.filePaths],
+    linkedIssues: [...detail.linkedIssues],
+    comments: detail.comments.map(cleanComment),
+    threads,
+  };
+
+  // The query caps the file listing, so the provider is the one who knows.
+  let truncated = detail.filesTruncated;
+
+  const bodyOvershoot = overshootChars(content);
+  if (bodyOvershoot > 0 && content.body.length > 0) {
+    content.body = cutTo(content.body, content.body.length - bodyOvershoot);
+    truncated = true;
+  }
+
+  const droppableOrder = threads
+    .map((thread, index) => ({ index, depth: thread.comments.length }))
+    .sort((a, b) => a.depth - b.depth || a.index - b.index)
+    .map(({ index }) => index);
+
+  const dropped = new Set<number>();
+  for (const index of droppableOrder) {
+    if (overshootChars(content) <= 0) break;
+    dropped.add(index);
+    content.threads = threads.filter((_, at) => !dropped.has(at));
+    truncated = true;
+  }
+
+  while (overshootChars(content) > 0 && content.comments.length > 0) {
+    content.comments = content.comments.slice(0, -1);
+    truncated = true;
+  }
+
+  return { content, truncated };
+}

--- a/apps/app/src/features/knowledge/server/collect/collect-run.test.ts
+++ b/apps/app/src/features/knowledge/server/collect/collect-run.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => ({
+  knowledgeCollectionRun: {
+    update: vi.fn(),
+    updateMany: vi.fn(),
+    findFirst: vi.fn(),
+  },
+  knowledgeBundle: { findMany: vi.fn(), upsert: vi.fn() },
+}));
+const github = vi.hoisted(() => ({
+  resolveRepositoryConnection: vi.fn(),
+  listMergedPullRequests: vi.fn(),
+  fetchPullRequestDetail: vi.fn(),
+}));
+
+vi.mock("@scibly/db", () => ({ db, Prisma: { DbNull: "DbNull" } }));
+vi.mock("@/features/integrations/server", () => github);
+
+const { collectRepository, recordFailedCollection } =
+  await import("./collect-run");
+
+const request = {
+  runId: "run-1",
+  organizationId: "org-1",
+  repositoryId: "42",
+};
+
+const WATERMARK = new Date("2026-08-01T00:00:00Z");
+const TOUCHED = new Date("2026-08-02T00:00:00Z");
+
+const pullRequest = {
+  externalId: "PR_1",
+  number: 7,
+  title: "Give the scheduler a per-account lock",
+  authorLogin: "ada",
+  authorType: "User",
+  labels: ["design"],
+  commentCount: 6,
+  updatedAt: TOUCHED,
+  mergedAt: TOUCHED,
+  url: "https://github.com/acme/api/pull/7",
+};
+
+const succeededWith = () =>
+  db.knowledgeCollectionRun.update.mock.calls.find(
+    ([call]) => call.data.status === "SUCCEEDED",
+  )?.[0].data;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  github.resolveRepositoryConnection.mockResolvedValue({
+    token: "ghs_secret",
+    provider: { resolveGrant: vi.fn().mockResolvedValue({ name: "acme/api" }) },
+  });
+  github.listMergedPullRequests.mockResolvedValue({
+    pullRequests: [],
+    nextCursor: null,
+  });
+  db.knowledgeCollectionRun.findFirst.mockResolvedValue({
+    collectedThrough: WATERMARK,
+  });
+  db.knowledgeBundle.findMany.mockResolvedValue([]);
+});
+
+describe("the watermark advances on success alone", () => {
+  it("only ever reads it off a run that succeeded", async () => {
+    await collectRepository(request);
+
+    const [{ where }] = db.knowledgeCollectionRun.findFirst.mock.calls[0];
+    expect(where.status).toBe("SUCCEEDED");
+  });
+
+  it("plants it and collects nothing on the first run", async () => {
+    db.knowledgeCollectionRun.findFirst.mockResolvedValue(null);
+
+    expect(await collectRepository(request)).toEqual({
+      collected: 0,
+      discarded: 0,
+      capped: false,
+    });
+    expect(github.listMergedPullRequests).not.toHaveBeenCalled();
+    expect(succeededWith()?.collectedThrough).toBeInstanceOf(Date);
+  });
+
+  it("writes no successful run when the repository is out of reach", async () => {
+    github.resolveRepositoryConnection.mockResolvedValue({
+      token: "ghs_secret",
+      provider: { resolveGrant: vi.fn().mockResolvedValue(null) },
+    });
+
+    await expect(collectRepository(request)).rejects.toThrow(/reaches/);
+    expect(succeededWith()).toBeUndefined();
+  });
+
+  it("collects the newest slice and owns the gap when the listing never ends", async () => {
+    github.listMergedPullRequests.mockResolvedValue({
+      pullRequests: [pullRequest],
+      nextCursor: "next",
+    });
+
+    expect(await collectRepository(request)).toEqual({
+      collected: 0,
+      discarded: 0,
+      capped: true,
+    });
+    expect(succeededWith()?.capped).toBe(true);
+  });
+
+  it("keeps the message when Inngest hands the error over serialized", async () => {
+    // What `onFailure` actually receives: no prototype, just the fields.
+    await recordFailedCollection("run-1", {
+      name: "Error",
+      message: "GitHub said 401",
+    });
+
+    const [{ data }] = db.knowledgeCollectionRun.updateMany.mock.calls[0];
+    expect(data.failureReason).toBe("GitHub said 401");
+  });
+
+  it("marks the run failed without touching the watermark", async () => {
+    await recordFailedCollection("run-1", new Error("GitHub said 502"));
+
+    const [{ where, data }] =
+      db.knowledgeCollectionRun.updateMany.mock.calls[0];
+    expect(where.id).toBe("run-1");
+    expect(data.status).toBe("FAILED");
+    expect(data.failureReason).toBe("GitHub said 502");
+    expect(data).not.toHaveProperty("collectedThrough");
+  });
+});
+
+describe("a re-run over pull requests nothing has happened to", () => {
+  it("stores nothing and never asks for a pull request in full", async () => {
+    github.listMergedPullRequests.mockResolvedValue({
+      pullRequests: [pullRequest],
+      nextCursor: null,
+    });
+    db.knowledgeBundle.findMany.mockResolvedValue([
+      { externalId: "PR_1", githubUpdatedAt: TOUCHED },
+    ]);
+
+    expect(await collectRepository(request)).toEqual({
+      collected: 0,
+      discarded: 0,
+      capped: false,
+    });
+    expect(github.fetchPullRequestDetail).not.toHaveBeenCalled();
+    expect(db.knowledgeBundle.upsert).not.toHaveBeenCalled();
+    expect(succeededWith()?.collectedThrough).toBe(TOUCHED);
+  });
+
+  it("judges one the cheap way when its discussion has moved on", async () => {
+    github.listMergedPullRequests.mockResolvedValue({
+      pullRequests: [{ ...pullRequest, commentCount: 1 }],
+      nextCursor: null,
+    });
+
+    expect(await collectRepository(request)).toEqual({
+      collected: 0,
+      discarded: 1,
+      capped: false,
+    });
+    expect(github.fetchPullRequestDetail).not.toHaveBeenCalled();
+    const [{ create }] = db.knowledgeBundle.upsert.mock.calls[0];
+    expect(create.discardReason).toBe("NO_DISCUSSION");
+  });
+});

--- a/apps/app/src/features/knowledge/server/collect/collect-run.ts
+++ b/apps/app/src/features/knowledge/server/collect/collect-run.ts
@@ -1,0 +1,326 @@
+import type { KnowledgeDiscardReason } from "@scibly/db/enums";
+import type {
+  PullRequestDetail,
+  PullRequestSummary,
+} from "@/features/integrations/server";
+import type { BundleContent } from "./bundle";
+
+import { db, Prisma } from "@scibly/db";
+
+import {
+  fetchPullRequestDetail,
+  listMergedPullRequests,
+  resolveRepositoryConnection,
+} from "@/features/integrations/server";
+
+import { requireReachableRepository } from "../topic-scope";
+import { buildBundleContent } from "./bundle";
+import {
+  isDenseEnough,
+  rejectFromSummary,
+  scoreDiscussionDensity,
+} from "./structural-filter";
+
+// ponytail: 50 details fits the route's 300s ceiling; wrap each pull request in
+// its own `step.run` if that ever needs to be higher.
+const COLLECT_BUDGET = {
+  pageSize: 50,
+  maxPages: 10,
+  maxDetails: 50,
+  /** GitHub's secondary limits punish concurrency, not volume — keep this small. */
+  detailConcurrency: 5,
+} as const;
+
+export interface CollectionResult {
+  collected: number;
+  discarded: number;
+  capped: boolean;
+}
+
+async function readWatermark(
+  organizationId: string,
+  repositoryId: string,
+): Promise<Date | null> {
+  const previous = await db.knowledgeCollectionRun.findFirst({
+    where: {
+      organizationId,
+      repositoryId,
+      status: "SUCCEEDED",
+      collectedThrough: { not: null },
+    },
+    orderBy: { collectedThrough: "desc" },
+    select: { collectedThrough: true },
+  });
+  return previous?.collectedThrough ?? null;
+}
+
+// The bound is inclusive: a second pull request sharing the watermark's
+// timestamp would otherwise be lost, and re-seeing one is cheap.
+async function listSinceWatermark(
+  token: string,
+  repositoryFullName: string,
+  watermark: Date,
+): Promise<{ fresh: PullRequestSummary[]; capped: boolean }> {
+  const fresh: PullRequestSummary[] = [];
+  let cursor: string | null = null;
+
+  for (let page = 0; page < COLLECT_BUDGET.maxPages; page++) {
+    const listing = await listMergedPullRequests(token, repositoryFullName, {
+      pageSize: COLLECT_BUDGET.pageSize,
+      cursor,
+    });
+    for (const pullRequest of listing.pullRequests) {
+      if (pullRequest.updatedAt < watermark) return { fresh, capped: false };
+      fresh.push(pullRequest);
+    }
+    if (!listing.nextCursor) return { fresh, capped: false };
+    cursor = listing.nextCursor;
+  }
+  // Pages exhausted before the watermark: keep the newest slice and own the
+  // gap via `capped` — failing here would wedge the repository forever.
+  return { fresh, capped: true };
+}
+
+// ponytail: fixed chunks, not a sliding pool — at 50 details the idle tail
+// costs nothing worth a scheduler.
+async function fetchDetails(
+  token: string,
+  externalIds: string[],
+): Promise<Map<string, PullRequestDetail | null>> {
+  const byId = new Map<string, PullRequestDetail | null>();
+  for (
+    let at = 0;
+    at < externalIds.length;
+    at += COLLECT_BUDGET.detailConcurrency
+  ) {
+    const chunk = externalIds.slice(at, at + COLLECT_BUDGET.detailConcurrency);
+    const fetched = await Promise.all(
+      chunk.map((externalId) => fetchPullRequestDetail(token, externalId)),
+    );
+    chunk.forEach((externalId, index) =>
+      byId.set(externalId, fetched[index] ?? null),
+    );
+  }
+  return byId;
+}
+
+type BundleRow = {
+  number: number;
+  githubUpdatedAt: Date;
+  mergedAt: Date | null;
+  score: number | null;
+  discardReason: KnowledgeDiscardReason | null;
+  content: Prisma.InputJsonValue | typeof Prisma.DbNull;
+  /// Denormalized from `content` so the feed never loads the whole conversation.
+  title: string | null;
+  url: string | null;
+  filePaths: string[];
+  truncated: boolean;
+  collectedAt: Date;
+};
+
+const discardRow = (
+  pullRequest: PullRequestSummary,
+  reason: KnowledgeDiscardReason,
+  score: number | null,
+): BundleRow => ({
+  number: pullRequest.number,
+  githubUpdatedAt: pullRequest.updatedAt,
+  mergedAt: null,
+  score,
+  discardReason: reason,
+  // SQL NULL, not JSON null: `discardReason` is set exactly when this is unset.
+  content: Prisma.DbNull,
+  title: null,
+  url: null,
+  filePaths: [],
+  truncated: false,
+  collectedAt: new Date(),
+});
+
+const bundleRow = (
+  pullRequest: PullRequestSummary,
+  content: BundleContent,
+  truncated: boolean,
+  score: number,
+): BundleRow => ({
+  number: pullRequest.number,
+  githubUpdatedAt: pullRequest.updatedAt,
+  mergedAt: pullRequest.mergedAt,
+  score,
+  discardReason: null,
+  content,
+  title: content.title,
+  url: content.url,
+  filePaths: content.filePaths,
+  truncated,
+  collectedAt: new Date(),
+});
+
+const finish = (runId: string, result: CollectionResult, through: Date) =>
+  db.knowledgeCollectionRun.update({
+    where: { id: runId },
+    data: {
+      status: "SUCCEEDED",
+      finishedAt: new Date(),
+      collectedThrough: through,
+      ...result,
+    },
+  });
+
+/** Throws on failure so Inngest retries; its `onFailure` writes the FAILED row. */
+export async function collectRepository({
+  runId,
+  organizationId,
+  repositoryId,
+}: {
+  runId: string;
+  organizationId: string;
+  repositoryId: string;
+}): Promise<CollectionResult> {
+  const startedAt = new Date();
+  await db.knowledgeCollectionRun.update({
+    where: { id: runId },
+    data: { status: "RUNNING", startedAt },
+  });
+
+  const connection = await resolveRepositoryConnection(
+    organizationId,
+    "GITHUB",
+  );
+  // GitHub's GraphQL cannot address a repository by the stored database id, so
+  // the name is resolved once — which also settles reachability.
+  const repositoryFullName = await requireReachableRepository(
+    connection,
+    repositoryId,
+  );
+
+  const watermark = await readWatermark(organizationId, repositoryId);
+  // The first run only plants the watermark — backfilling a repository's
+  // history is its own ticket, scibly-dev/scibly#16.
+  if (!watermark) {
+    await finish(
+      runId,
+      { collected: 0, discarded: 0, capped: false },
+      startedAt,
+    );
+    return { collected: 0, discarded: 0, capped: false };
+  }
+
+  const { fresh, capped: listingCapped } = await listSinceWatermark(
+    connection.token,
+    repositoryFullName,
+    watermark,
+  );
+  // Oldest first: a budget-stopped run resumes exactly where it stopped.
+  fresh.reverse();
+
+  const known = new Map(
+    (
+      await db.knowledgeBundle.findMany({
+        where: {
+          organizationId,
+          repositoryId,
+          externalId: {
+            in: fresh.map((pullRequest) => pullRequest.externalId),
+          },
+        },
+        select: { externalId: true, githubUpdatedAt: true },
+      })
+    ).map((row) => [row.externalId, row.githubUpdatedAt.getTime()]),
+  );
+
+  const unchanged = (pullRequest: PullRequestSummary) =>
+    known.get(pullRequest.externalId) === pullRequest.updatedAt.getTime();
+
+  // Must mirror the walk below: same two predicates, same budget.
+  const wanted: string[] = [];
+  for (const pullRequest of fresh) {
+    if (unchanged(pullRequest) || rejectFromSummary(pullRequest)) continue;
+    if (wanted.length >= COLLECT_BUDGET.maxDetails) break;
+    wanted.push(pullRequest.externalId);
+  }
+  const detailById = await fetchDetails(connection.token, wanted);
+
+  let collected = 0;
+  let discarded = 0;
+  let details = 0;
+  let capped = listingCapped;
+  let collectedThrough = watermark;
+
+  for (const pullRequest of fresh) {
+    if (unchanged(pullRequest)) {
+      collectedThrough = pullRequest.updatedAt;
+      continue;
+    }
+
+    const refused = rejectFromSummary(pullRequest);
+    let row: BundleRow;
+    if (refused) {
+      row = discardRow(pullRequest, refused, null);
+    } else {
+      if (details >= COLLECT_BUDGET.maxDetails) {
+        capped = true;
+        break;
+      }
+      details++;
+      const detail = detailById.get(pullRequest.externalId) ?? null;
+      // Deleted, or moved out of reach between the listing and now.
+      if (!detail) {
+        collectedThrough = pullRequest.updatedAt;
+        continue;
+      }
+      const score = scoreDiscussionDensity(detail);
+      const { content, truncated } = buildBundleContent(detail);
+      row = isDenseEnough(score)
+        ? bundleRow(pullRequest, content, truncated, score)
+        : discardRow(pullRequest, "LOW_DENSITY", score);
+    }
+
+    await db.knowledgeBundle.upsert({
+      where: {
+        organizationId_repositoryId_externalId: {
+          organizationId,
+          repositoryId,
+          externalId: pullRequest.externalId,
+        },
+      },
+      create: {
+        organizationId,
+        repositoryId,
+        externalId: pullRequest.externalId,
+        ...row,
+      },
+      update: row,
+    });
+
+    if (row.discardReason) discarded++;
+    else collected++;
+    collectedThrough = pullRequest.updatedAt;
+  }
+
+  const result = { collected, discarded, capped };
+  await finish(runId, result, collectedThrough);
+  return result;
+}
+
+/** GitHub's own message, truncated — never a credential, which the provider strips. */
+export async function recordFailedCollection(
+  runId: string,
+  error: unknown,
+): Promise<void> {
+  // Inngest serializes the error to a plain object `String()` would render
+  // "[object Object]".
+  const reason =
+    typeof error === "object" && error !== null && "message" in error
+      ? String(error.message)
+      : String(error);
+  await db.knowledgeCollectionRun.updateMany({
+    where: { id: runId, status: { in: ["QUEUED", "RUNNING"] } },
+    data: {
+      status: "FAILED",
+      finishedAt: new Date(),
+      failureReason: reason.slice(0, 500),
+    },
+  });
+}

--- a/apps/app/src/features/knowledge/server/collect/collection-sync.ts
+++ b/apps/app/src/features/knowledge/server/collect/collection-sync.ts
@@ -1,0 +1,151 @@
+import { decideKnowledgeSync } from "@scibly/api/entitlement";
+import { db, Prisma } from "@scibly/db";
+import { z } from "zod";
+
+import { inngest } from "@/lib/inngest/client";
+
+import { parseStoredRepositories } from "../topic-repositories";
+import { collectRepository, recordFailedCollection } from "./collect-run";
+
+export const KNOWLEDGE_COLLECT_EVENT = "scibly/knowledge-collect.requested";
+
+// Never a credential: the event log is not a place for tokens.
+const collectRequest = z.object({
+  runId: z.string().min(1),
+  organizationId: z.string().min(1),
+  repositoryId: z.string().min(1),
+});
+
+type CollectRequest = z.infer<typeof collectRequest>;
+
+/**
+ * One QUEUED run per repository: a partial unique index backs the check, so two
+ * callers racing past the read both land on the one row.
+ */
+async function queueCollection(
+  organizationId: string,
+  repositoryId: string,
+): Promise<CollectRequest> {
+  const waiting = await db.knowledgeCollectionRun.findFirst({
+    where: { organizationId, repositoryId, status: "QUEUED" },
+    select: { id: true },
+  });
+  const run =
+    waiting ??
+    (await db.knowledgeCollectionRun
+      .create({
+        data: { organizationId, repositoryId },
+        select: { id: true },
+      })
+      .catch(async (error) => {
+        if (
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          error.code === "P2002"
+        ) {
+          return db.knowledgeCollectionRun.findFirstOrThrow({
+            where: { organizationId, repositoryId, status: "QUEUED" },
+            select: { id: true },
+          });
+        }
+        throw error;
+      }));
+  return { runId: run.id, organizationId, repositoryId };
+}
+
+/**
+ * Every trigger goes through here: run rows first, then the events, so the feed
+ * always has something to show for a request that was made.
+ */
+export async function requestCollections(
+  pairs: [organizationId: string, repositoryId: string][],
+  send: (events: { name: string; data: CollectRequest }[]) => Promise<void>,
+): Promise<{ requested: number }> {
+  if (pairs.length === 0) return { requested: 0 };
+  const requests = await Promise.all(
+    pairs.map(([organizationId, repositoryId]) =>
+      queueCollection(organizationId, repositoryId),
+    ),
+  );
+  try {
+    await send(
+      requests.map((data) => ({ name: KNOWLEDGE_COLLECT_EVENT, data })),
+    );
+  } catch (error) {
+    // A failed send marks the queued rows FAILED — nothing would ever finish them.
+    await Promise.all(
+      requests.map(({ runId }) => recordFailedCollection(runId, error)),
+    );
+    throw error;
+  }
+  return { requested: requests.length };
+}
+
+async function dueRepositories(): Promise<[string, string][]> {
+  const topics = await db.knowledgeTopic.findMany({
+    select: { organizationId: true, repositories: true },
+  });
+
+  const byOrg = new Map<string, Set<string>>();
+  for (const topic of topics) {
+    const repositories = byOrg.get(topic.organizationId) ?? new Set<string>();
+    for (const { id } of parseStoredRepositories(topic.repositories)) {
+      repositories.add(id);
+    }
+    byOrg.set(topic.organizationId, repositories);
+  }
+
+  const due: [string, string][] = [];
+  for (const [organizationId, repositories] of byOrg) {
+    // A lapsed or downgraded organization keeps its topics and stops collecting.
+    const { refusal } = await decideKnowledgeSync(db, organizationId);
+    if (refusal) continue;
+    for (const repositoryId of repositories)
+      due.push([organizationId, repositoryId]);
+  }
+  return due;
+}
+
+export async function requestDueCollections(
+  sendEvent: (
+    id: string,
+    events: { name: string; data: CollectRequest }[],
+  ) => Promise<void>,
+): Promise<{ requested: number }> {
+  return requestCollections(await dueRepositories(), (events) =>
+    sendEvent("request-collections", events),
+  );
+}
+
+export const knowledgeCollectionSync = inngest.createFunction(
+  {
+    id: "knowledge-collection-sync",
+    name: "Knowledge collection sync",
+    retries: 2,
+    // An hour after the integration poll, so both never queue against the same
+    // GitHub installation at once.
+    triggers: [{ cron: "0 5 * * *" }],
+  },
+  ({ step }) =>
+    requestDueCollections(async (id, events) => {
+      await step.sendEvent(id, events);
+    }),
+);
+
+export const knowledgeCollect = inngest.createFunction(
+  {
+    id: "knowledge-collect",
+    name: "Knowledge collect",
+    retries: 2,
+    concurrency: [
+      { key: "event.data.organizationId", limit: 3 },
+      { key: "event.data.repositoryId", limit: 1 },
+    ],
+    triggers: [{ event: KNOWLEDGE_COLLECT_EVENT }],
+    onFailure: ({ event }) =>
+      recordFailedCollection(
+        collectRequest.parse(event.data.event.data).runId,
+        event.data.error,
+      ),
+  },
+  ({ event }) => collectRepository(collectRequest.parse(event.data)),
+);

--- a/apps/app/src/features/knowledge/server/collect/e2e-live-db.test.ts
+++ b/apps/app/src/features/knowledge/server/collect/e2e-live-db.test.ts
@@ -1,0 +1,429 @@
+// @vitest-environment node
+/**
+ * End-to-end against the real dev Postgres; only GitHub's network boundary is doubled.
+ *   E2E_DATABASE_URL=postgres://… pnpm vitest run src/features/knowledge/server/collect/e2e-live-db.test.ts
+ */
+const live = process.env.E2E_DATABASE_URL;
+if (live) process.env.DATABASE_URL = live;
+
+import type {
+  PullRequestDetail,
+  PullRequestSummary,
+} from "@/features/integrations/server";
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const github = vi.hoisted(() => ({
+  resolveRepositoryConnection: vi.fn(),
+  listMergedPullRequests: vi.fn(),
+  fetchPullRequestDetail: vi.fn(),
+}));
+vi.mock("@/features/integrations/server", () => github);
+
+const { db } = await import("@scibly/db");
+const { collectRepository, recordFailedCollection } =
+  await import("./collect-run");
+const { KNOWLEDGE_COLLECT_EVENT, requestCollections, requestDueCollections } =
+  await import("./collection-sync");
+const { parseStoredRepositories } = await import("../topic-repositories");
+
+const ORG = "org_dummy_dev_id";
+const REPO = "e2e-collect-repo";
+const FULL_NAME = "acme/api";
+
+// Fixtures must be newer than the watermark the first run plants; `base` is
+// reassigned to it there.
+let base = new Date();
+const at = (minutes: number) => new Date(base.getTime() + minutes * 60_000);
+
+const summary = (
+  over: Partial<PullRequestSummary> = {},
+): PullRequestSummary => ({
+  externalId: "PR_rich",
+  number: 7,
+  title: "Give the scheduler a per-account lock",
+  authorLogin: "ada",
+  authorType: "User",
+  labels: ["design"],
+  commentCount: 6,
+  updatedAt: at(1),
+  mergedAt: at(0),
+  url: "https://github.com/acme/api/pull/7",
+  ...over,
+});
+
+const comment = (body: string) => ({
+  author: "ada",
+  body,
+  url: "https://github.com/acme/api/pull/7#c",
+  diffHunk: "@@ -1,3 +1,4 @@\n-old\n+new",
+});
+
+const richDetail = (
+  over: Partial<PullRequestDetail> = {},
+): PullRequestDetail => ({
+  externalId: "PR_rich",
+  number: 7,
+  title: "Give the scheduler a per-account lock",
+  body: "A global lock serialises every account behind the slowest one. ".repeat(
+    12,
+  ),
+  url: "https://github.com/acme/api/pull/7",
+  labels: ["design"],
+  filePaths: ["src/scheduler.ts", "src/queue.ts"],
+  filesTruncated: false,
+  linkedIssues: [
+    { number: 3, title: "Scheduler stalls", url: "https://x/3" },
+    { number: 4, title: "Lock contention", url: "https://x/4" },
+  ],
+  comments: [comment("Why not a global lock? ".repeat(20))],
+  threads: [
+    {
+      path: "src/scheduler.ts",
+      isResolved: false,
+      comments: [
+        comment("Does this hold across restarts? ".repeat(15)),
+        comment("It does — the lease is in Postgres. ".repeat(15)),
+      ],
+    },
+    {
+      path: "src/queue.ts",
+      isResolved: true,
+      comments: [comment("Nit: rename."), comment("Done.")],
+    },
+  ],
+  mergedAt: at(0),
+  updatedAt: at(1),
+  ...over,
+});
+
+const wipe = () =>
+  Promise.all([
+    db.knowledgeBundle.deleteMany({
+      where: { organizationId: ORG, repositoryId: REPO },
+    }),
+    db.knowledgeCollectionRun.deleteMany({
+      where: { organizationId: ORG, repositoryId: REPO },
+    }),
+  ]);
+
+const newRun = async () =>
+  (
+    await db.knowledgeCollectionRun.create({
+      data: { organizationId: ORG, repositoryId: REPO },
+      select: { id: true },
+    })
+  ).id;
+
+const run = async (runId: string) =>
+  collectRepository({ runId, organizationId: ORG, repositoryId: REPO });
+
+const runRow = (id: string) =>
+  db.knowledgeCollectionRun.findUniqueOrThrow({ where: { id } });
+
+beforeAll(async () => {
+  const organization = await db.organization.findUnique({
+    where: { id: ORG },
+    select: { id: true },
+  });
+  if (!organization) throw new Error(`Dev fixture org ${ORG} is missing.`);
+  await wipe();
+  github.resolveRepositoryConnection.mockResolvedValue({
+    token: "ghs_double",
+    provider: {
+      resolveGrant: vi.fn().mockResolvedValue({ id: REPO, name: FULL_NAME }),
+    },
+  });
+});
+
+afterAll(async () => {
+  await wipe();
+  await db.$disconnect();
+});
+
+describe.runIf(live)("a repository collected against the real database", () => {
+  it("plants the watermark on the first run and asks GitHub for nothing", async () => {
+    const id = await newRun();
+
+    expect(await run(id)).toEqual({
+      collected: 0,
+      discarded: 0,
+      capped: false,
+    });
+    expect(github.listMergedPullRequests).not.toHaveBeenCalled();
+
+    const row = await runRow(id);
+    expect(row.status).toBe("SUCCEEDED");
+    expect(row.collectedThrough).toBeInstanceOf(Date);
+    base = row.collectedThrough!;
+  });
+
+  it("keeps what was argued over and refuses the rest", async () => {
+    github.listMergedPullRequests.mockResolvedValue({
+      // Newest first, the way GitHub answers — the collector reverses it.
+      pullRequests: [
+        summary({
+          externalId: "PR_quiet",
+          number: 9,
+          title: "Fix off-by-one in the cursor",
+          commentCount: 0,
+          updatedAt: at(3),
+        }),
+        summary({
+          externalId: "PR_bot",
+          number: 8,
+          authorLogin: "dependabot[bot]",
+          authorType: "Bot",
+          title: "Bump lodash from 4.17.20 to 4.17.21",
+          updatedAt: at(2),
+        }),
+        summary(),
+      ],
+      nextCursor: null,
+    });
+    github.fetchPullRequestDetail.mockResolvedValue(richDetail());
+
+    const id = await newRun();
+    expect(await run(id)).toEqual({
+      collected: 1,
+      discarded: 2,
+      capped: false,
+    });
+
+    expect(github.fetchPullRequestDetail).toHaveBeenCalledTimes(1);
+
+    const bundles = await db.knowledgeBundle.findMany({
+      where: { organizationId: ORG, repositoryId: REPO },
+      orderBy: { number: "asc" },
+    });
+    expect(bundles.map((b) => [b.number, b.discardReason])).toEqual([
+      [7, null],
+      [8, "BOT_AUTHOR"],
+      [9, "NO_DISCUSSION"],
+    ]);
+
+    const kept = bundles[0]!;
+    expect(kept.content).not.toBeNull();
+    expect(kept.mergedAt).toBeInstanceOf(Date);
+    expect(kept.score).toBeGreaterThanOrEqual(30);
+    const content = kept.content as {
+      threads: { comments: { diffHunk: string | null }[] }[];
+    };
+    expect(content.threads[0]!.comments[0]!.diffHunk).toContain("@@");
+    expect(JSON.stringify(kept.content).length / 4).toBeLessThanOrEqual(6_000);
+
+    // Discarded rows must hold SQL NULL, not JSON null.
+    const nulls = await db.$queryRawUnsafe<{ n: bigint }[]>(
+      `select count(*) as n from knowledge_bundle
+       where "organizationId" = $1 and "repositoryId" = $2 and content is null`,
+      ORG,
+      REPO,
+    );
+    expect(Number(nulls[0]!.n)).toBe(2);
+
+    const row = await runRow(id);
+    expect(row.status).toBe("SUCCEEDED");
+    expect(row.collected).toBe(1);
+    expect(row.discarded).toBe(2);
+    expect(row.collectedThrough).toEqual(at(3));
+  });
+
+  it("is a no-op when the same pull requests come back unchanged", async () => {
+    github.fetchPullRequestDetail.mockClear();
+    const before = await db.knowledgeBundle.findMany({
+      where: { organizationId: ORG, repositoryId: REPO },
+      select: { externalId: true, githubUpdatedAt: true, collectedAt: true },
+      orderBy: { number: "asc" },
+    });
+
+    const id = await newRun();
+    expect(await run(id)).toEqual({
+      collected: 0,
+      discarded: 0,
+      capped: false,
+    });
+    expect(github.fetchPullRequestDetail).not.toHaveBeenCalled();
+
+    const after = await db.knowledgeBundle.findMany({
+      where: { organizationId: ORG, repositoryId: REPO },
+      select: { externalId: true, githubUpdatedAt: true, collectedAt: true },
+      orderBy: { number: "asc" },
+    });
+    expect(after).toEqual(before);
+  });
+
+  it("collects again once the discussion has actually moved", async () => {
+    const moved = at(10);
+    github.listMergedPullRequests.mockResolvedValue({
+      pullRequests: [summary({ commentCount: 9, updatedAt: moved })],
+      nextCursor: null,
+    });
+    github.fetchPullRequestDetail.mockResolvedValue(
+      richDetail({
+        updatedAt: moved,
+        comments: [
+          comment("Why not a global lock? ".repeat(20)),
+          comment("Because the lease has to be per account. ".repeat(20)),
+        ],
+      }),
+    );
+    const before = await db.knowledgeBundle.findUniqueOrThrow({
+      where: {
+        organizationId_repositoryId_externalId: {
+          organizationId: ORG,
+          repositoryId: REPO,
+          externalId: "PR_rich",
+        },
+      },
+    });
+
+    const id = await newRun();
+    expect(await run(id)).toEqual({
+      collected: 1,
+      discarded: 0,
+      capped: false,
+    });
+
+    const after = await db.knowledgeBundle.findUniqueOrThrow({
+      where: { id: before.id },
+    });
+    expect(after.content).not.toEqual(before.content);
+    expect(after.githubUpdatedAt).toEqual(moved);
+    expect(
+      await db.knowledgeBundle.count({
+        where: { organizationId: ORG, repositoryId: REPO },
+      }),
+    ).toBe(3);
+  });
+
+  it("cuts an oversized pull request down and says so on the row", async () => {
+    const huge = at(20);
+    github.listMergedPullRequests.mockResolvedValue({
+      pullRequests: [
+        summary({ externalId: "PR_huge", number: 11, updatedAt: huge }),
+      ],
+      nextCursor: null,
+    });
+    github.fetchPullRequestDetail.mockResolvedValue(
+      richDetail({
+        externalId: "PR_huge",
+        number: 11,
+        updatedAt: huge,
+        body: "x".repeat(80_000),
+      }),
+    );
+
+    const id = await newRun();
+    expect((await run(id)).collected).toBe(1);
+
+    const row = await db.knowledgeBundle.findUniqueOrThrow({
+      where: {
+        organizationId_repositoryId_externalId: {
+          organizationId: ORG,
+          repositoryId: REPO,
+          externalId: "PR_huge",
+        },
+      },
+    });
+    expect(row.truncated).toBe(true);
+    expect(JSON.stringify(row.content).length / 4).toBeLessThanOrEqual(6_000);
+  });
+
+  it("leaves the watermark alone when the run fails", async () => {
+    const before = await db.knowledgeCollectionRun.findFirstOrThrow({
+      where: { organizationId: ORG, repositoryId: REPO, status: "SUCCEEDED" },
+      orderBy: { collectedThrough: "desc" },
+    });
+    github.listMergedPullRequests.mockRejectedValue(
+      new Error("GitHub said 502"),
+    );
+
+    const id = await newRun();
+    await expect(run(id)).rejects.toThrow("GitHub said 502");
+    await recordFailedCollection(id, new Error("GitHub said 502"));
+
+    const failed = await runRow(id);
+    expect(failed.status).toBe("FAILED");
+    expect(failed.failureReason).toBe("GitHub said 502");
+    expect(failed.collectedThrough).toBeNull();
+
+    const watermark = await db.knowledgeCollectionRun.findFirstOrThrow({
+      where: { organizationId: ORG, repositoryId: REPO, status: "SUCCEEDED" },
+      orderBy: { collectedThrough: "desc" },
+    });
+    expect(watermark.collectedThrough).toEqual(before.collectedThrough);
+  });
+});
+
+describe.runIf(live)("queueing a collection", () => {
+  it("reuses the run already waiting rather than piling them up", async () => {
+    const sent: { data: { runId: string } }[] = [];
+    const record = async (events: { data: { runId: string } }[]) => {
+      sent.push(...events);
+    };
+
+    await requestCollections([[ORG, REPO]], record);
+    await requestCollections([[ORG, REPO]], record);
+
+    expect(sent[1]!.data.runId).toBe(sent[0]!.data.runId);
+    expect(
+      await db.knowledgeCollectionRun.count({
+        where: { organizationId: ORG, repositoryId: REPO, status: "QUEUED" },
+      }),
+    ).toBe(1);
+  });
+
+  it("fails the run it could not hand off", async () => {
+    const sent: { data: { runId: string } }[] = [];
+
+    await expect(
+      requestCollections([[ORG, REPO]], async (events) => {
+        sent.push(...events);
+        throw new Error("Inngest unreachable");
+      }),
+    ).rejects.toThrow("Inngest unreachable");
+
+    const row = await runRow(sent[0]!.data.runId);
+    expect(row.status).toBe("FAILED");
+    expect(row.failureReason).toBe("Inngest unreachable");
+  });
+});
+
+describe.runIf(live)("the nightly fan-out", () => {
+  it("asks for every repository a topic watches, once each", async () => {
+    const topics = await db.knowledgeTopic.findMany({
+      select: { organizationId: true, repositories: true },
+    });
+    const expected = new Set(
+      topics.flatMap((topic) =>
+        parseStoredRepositories(topic.repositories).map(
+          ({ id }) => `${topic.organizationId}:${id}`,
+        ),
+      ),
+    );
+
+    const sent: { name: string; data: { runId: string } }[] = [];
+    const { requested } = await requestDueCollections(async (_id, events) => {
+      sent.push(...events);
+    });
+
+    try {
+      expect(requested).toBe(sent.length);
+      expect(sent.every((e) => e.name === KNOWLEDGE_COLLECT_EVENT)).toBe(true);
+      const queued = await db.knowledgeCollectionRun.findMany({
+        where: { id: { in: sent.map((e) => e.data.runId) } },
+        select: { organizationId: true, repositoryId: true, status: true },
+      });
+      expect(queued).toHaveLength(sent.length);
+      expect(queued.every((run) => run.status === "QUEUED")).toBe(true);
+      const asked = queued.map((r) => `${r.organizationId}:${r.repositoryId}`);
+      expect(new Set(asked).size).toBe(asked.length);
+      // A subset, not equality: a lapsed organization keeps its topics and is skipped.
+      expect(asked.every((key) => expected.has(key))).toBe(true);
+    } finally {
+      await db.knowledgeCollectionRun.deleteMany({
+        where: { id: { in: sent.map((e) => e.data.runId) } },
+      });
+    }
+  });
+});

--- a/apps/app/src/features/knowledge/server/collect/structural-filter.test.ts
+++ b/apps/app/src/features/knowledge/server/collect/structural-filter.test.ts
@@ -1,0 +1,146 @@
+import type {
+  PullRequestDetail,
+  PullRequestSummary,
+} from "@/features/integrations/server";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  isDenseEnough,
+  rejectFromSummary,
+  scoreDiscussionDensity,
+} from "./structural-filter";
+
+const summary = (
+  overrides: Partial<PullRequestSummary> = {},
+): PullRequestSummary => ({
+  externalId: "PR_1",
+  number: 1,
+  title: "Give the scheduler a per-account lock",
+  authorLogin: "ada",
+  authorType: "User",
+  labels: [],
+  commentCount: 6,
+  updatedAt: new Date("2026-08-01T00:00:00Z"),
+  mergedAt: new Date("2026-08-01T00:00:00Z"),
+  url: "https://github.com/acme/api/pull/1",
+  ...overrides,
+});
+
+const comment = (body: string) => ({
+  author: "ada",
+  body,
+  url: "https://github.com/acme/api/pull/1#c1",
+  diffHunk: null,
+});
+
+const detail = (
+  overrides: Partial<PullRequestDetail> = {},
+): PullRequestDetail => ({
+  externalId: "PR_1",
+  number: 1,
+  title: "Give the scheduler a per-account lock",
+  body: "",
+  url: "https://github.com/acme/api/pull/1",
+  labels: [],
+  filePaths: ["src/scheduler.ts"],
+  filesTruncated: false,
+  linkedIssues: [],
+  comments: [],
+  threads: [],
+  mergedAt: new Date("2026-08-01T00:00:00Z"),
+  updatedAt: new Date("2026-08-01T00:00:00Z"),
+  ...overrides,
+});
+
+describe("what the listing alone is enough to refuse", () => {
+  it("drops a bot by its type, whatever it called itself", () => {
+    expect(
+      rejectFromSummary(
+        summary({ authorType: "Bot", authorLogin: "renovate" }),
+      ),
+    ).toBe("BOT_AUTHOR");
+  });
+
+  it("drops a bot by the login suffix, when the type is missing", () => {
+    expect(
+      rejectFromSummary(
+        summary({ authorType: null, authorLogin: "dependabot[bot]" }),
+      ),
+    ).toBe("BOT_AUTHOR");
+  });
+
+  it("drops a pull request nobody said anything about", () => {
+    expect(rejectFromSummary(summary({ commentCount: 1 }))).toBe(
+      "NO_DISCUSSION",
+    );
+  });
+
+  it("drops a dependency bump", () => {
+    expect(
+      rejectFromSummary(
+        summary({ title: "Bump zod from 3.23.8 to 4.0.1", commentCount: 3 }),
+      ),
+    ).toBe("CHORE_TITLE");
+  });
+
+  it("drops a typo fix", () => {
+    expect(
+      rejectFromSummary(
+        summary({ title: "Fix typo in README", commentCount: 2 }),
+      ),
+    ).toBe("CHORE_TITLE");
+  });
+
+  it("keeps a chore that turned into a real argument", () => {
+    expect(
+      rejectFromSummary(
+        summary({ title: "chore: drop the legacy poller", commentCount: 9 }),
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps a discussed change", () => {
+    expect(rejectFromSummary(summary())).toBeNull();
+  });
+});
+
+describe("how much was argued", () => {
+  it("keeps a pull request with a real description and deep threads", () => {
+    const score = scoreDiscussionDensity(
+      detail({
+        body: "x".repeat(500),
+        labels: ["design"],
+        threads: [
+          {
+            path: "src/scheduler.ts",
+            isResolved: true,
+            comments: [
+              comment("Why a global lock rather than one per account?"),
+              comment("y".repeat(400)),
+            ],
+          },
+          {
+            path: "src/scheduler.ts",
+            isResolved: false,
+            comments: [
+              comment("Same question for the retry path?"),
+              comment("Agreed."),
+            ],
+          },
+        ],
+      }),
+    );
+    expect(isDenseEnough(score)).toBe(true);
+  });
+
+  it("refuses a pull request whose comments are all one-liners", () => {
+    const score = scoreDiscussionDensity(
+      detail({
+        body: "Fixes the flake.",
+        comments: [comment("LGTM"), comment("ship it")],
+      }),
+    );
+    expect(isDenseEnough(score)).toBe(false);
+  });
+});

--- a/apps/app/src/features/knowledge/server/collect/structural-filter.ts
+++ b/apps/app/src/features/knowledge/server/collect/structural-filter.ts
@@ -1,0 +1,106 @@
+import type { KnowledgeDiscardReason } from "@scibly/db/enums";
+import type {
+  PullRequestDetail,
+  PullRequestSummary,
+} from "@/features/integrations/server";
+
+export const FILTER = {
+  minComments: 2,
+  choreDiscussionFloor: 5,
+  minScore: 30,
+
+  points: {
+    longBody: { chars: 400, points: 12 },
+    shortBody: { chars: 120, points: 6 },
+    deepThread: { minComments: 2, points: 10, cap: 4 },
+    substantiveComment: { chars: 300, points: 5, cap: 5 },
+    answeredQuestion: { points: 8, cap: 2 },
+    designLabel: { points: 15 },
+    linkedIssue: { points: 3, cap: 3 },
+  },
+
+  designLabelPattern:
+    /\b(design|architecture|rfc|proposal|discussion|decision|adr)\b/i,
+
+  chorePatterns: [
+    /^(chore|build|ci|style|deps|deps-dev|docs)(\([^)]*\))?!?:/i,
+    /^(bump|update) \S+ from \S+ to \S+/i,
+    /\btypos?\b/i,
+    /^release[: ]/i,
+    /^v?\d+\.\d+\.\d+\s*$/,
+  ],
+} as const;
+
+export function rejectFromSummary(
+  pullRequest: PullRequestSummary,
+): KnowledgeDiscardReason | null {
+  if (
+    pullRequest.authorType === "Bot" ||
+    /\[bot\]$/i.test(pullRequest.authorLogin ?? "")
+  ) {
+    return "BOT_AUTHOR";
+  }
+  if (pullRequest.commentCount < FILTER.minComments) return "NO_DISCUSSION";
+  if (
+    FILTER.chorePatterns.some((pattern) =>
+      pattern.test(pullRequest.title.trim()),
+    ) &&
+    pullRequest.commentCount < FILTER.choreDiscussionFloor
+  ) {
+    return "CHORE_TITLE";
+  }
+  return null;
+}
+
+const capped = (
+  count: number,
+  { points, cap }: { points: number; cap: number },
+) => Math.min(count, cap) * points;
+
+/** A question asked in one comment and replied to in the same thread. */
+const answeredQuestions = (detail: PullRequestDetail) =>
+  detail.threads.filter((thread) =>
+    thread.comments.some(
+      (comment, index) =>
+        comment.body.includes("?") && index < thread.comments.length - 1,
+    ),
+  ).length;
+
+/** Kept on the row even for discards, so the threshold can be tuned against real numbers. */
+export function scoreDiscussionDensity(detail: PullRequestDetail): number {
+  const { points } = FILTER;
+  const allComments = [
+    ...detail.comments,
+    ...detail.threads.flatMap((thread) => thread.comments),
+  ];
+
+  const bodyPoints =
+    detail.body.length >= points.longBody.chars
+      ? points.longBody.points
+      : detail.body.length >= points.shortBody.chars
+        ? points.shortBody.points
+        : 0;
+
+  return (
+    bodyPoints +
+    capped(
+      detail.threads.filter(
+        (thread) => thread.comments.length >= points.deepThread.minComments,
+      ).length,
+      points.deepThread,
+    ) +
+    capped(
+      allComments.filter(
+        (comment) => comment.body.length >= points.substantiveComment.chars,
+      ).length,
+      points.substantiveComment,
+    ) +
+    capped(answeredQuestions(detail), points.answeredQuestion) +
+    (detail.labels.some((label) => FILTER.designLabelPattern.test(label))
+      ? points.designLabel.points
+      : 0) +
+    capped(detail.linkedIssues.length, points.linkedIssue)
+  );
+}
+
+export const isDenseEnough = (score: number) => score >= FILTER.minScore;

--- a/apps/app/src/features/knowledge/server/collect/topic-feed.ts
+++ b/apps/app/src/features/knowledge/server/collect/topic-feed.ts
@@ -1,0 +1,91 @@
+import type { TopicRepository } from "../topic-repositories";
+
+import { db } from "@scibly/db";
+import { matchesGlob } from "path";
+
+/** A window, not pages: everything older lives in the topic document. */
+const FEED_WINDOW = { runs: 20, bundles: 50 } as const;
+
+// Empty globs means the topic watches the whole repository.
+const touchesScope = (filePaths: string[], pathGlobs: string[]) =>
+  pathGlobs.length === 0 ||
+  filePaths.some((filePath) =>
+    pathGlobs.some((glob) => matchesGlob(filePath, glob)),
+  );
+
+// A scope is per topic and a bundle is per repository, so path filtering
+// happens in JS after the windowed query.
+export async function loadTopicFeed(
+  organizationId: string,
+  repositories: TopicRepository[],
+) {
+  if (repositories.length === 0) return { runs: [], bundles: [] };
+  const repositoryIds = repositories.map((repository) => repository.id);
+  const nameById = new Map(
+    repositories.map((repository) => [repository.id, repository.fullName]),
+  );
+  const globsById = new Map(
+    repositories.map((repository) => [repository.id, repository.pathGlobs]),
+  );
+
+  const [runs, stored] = await Promise.all([
+    db.knowledgeCollectionRun.findMany({
+      where: { organizationId, repositoryId: { in: repositoryIds } },
+      orderBy: { startedAt: "desc" },
+      take: FEED_WINDOW.runs,
+      select: {
+        id: true,
+        repositoryId: true,
+        status: true,
+        startedAt: true,
+        collected: true,
+        discarded: true,
+        capped: true,
+        failureReason: true,
+      },
+    }),
+    db.knowledgeBundle.findMany({
+      where: {
+        organizationId,
+        repositoryId: { in: repositoryIds },
+        discardReason: null,
+      },
+      orderBy: { collectedAt: "desc" },
+      take: FEED_WINDOW.bundles,
+      // Never select `content`: the feed is polled.
+      select: {
+        id: true,
+        repositoryId: true,
+        number: true,
+        title: true,
+        url: true,
+        filePaths: true,
+        truncated: true,
+      },
+    }),
+  ]);
+
+  const bundles = stored.flatMap((bundle) => {
+    if (bundle.title === null || bundle.url === null) return [];
+    const globs = globsById.get(bundle.repositoryId) ?? [];
+    if (!touchesScope(bundle.filePaths, globs)) return [];
+    return [
+      {
+        id: bundle.id,
+        number: bundle.number,
+        title: bundle.title,
+        url: bundle.url,
+        repository: nameById.get(bundle.repositoryId) ?? bundle.repositoryId,
+        truncated: bundle.truncated,
+      },
+    ];
+  });
+
+  return {
+    runs: runs.map(({ repositoryId, ...run }) => ({
+      ...run,
+      repository: nameById.get(repositoryId) ?? repositoryId,
+    })),
+    bundles,
+  };
+}

--- a/apps/app/src/features/knowledge/server/topic-document.ts
+++ b/apps/app/src/features/knowledge/server/topic-document.ts
@@ -43,7 +43,7 @@ type PublishedColumns = {
   externallyEditedAt: null;
 };
 
-export type TopicDocumentResult =
+type TopicDocumentResult =
   | { outcome: "published"; columns: PublishedColumns }
   | {
       outcome: "externallyEdited";
@@ -148,8 +148,7 @@ export async function setDocumentDestination(
 }
 
 // ponytail: Notion truncates `last_edited_time` to the minute, so an outside
-// edit landing in the same minute as ours goes unseen. Compare the page's
-// markdown instead if that ever costs someone their words.
+// edit in the same minute as ours goes unseen — compare markdown if that ever costs someone their words.
 async function isOurs(
   provider: NotionConnection["provider"],
   token: string,

--- a/apps/app/src/features/knowledge/server/topic-scope.ts
+++ b/apps/app/src/features/knowledge/server/topic-scope.ts
@@ -5,7 +5,7 @@ import { db } from "@scibly/db";
 
 import { resolveRepositoryConnection } from "@/features/integrations/server";
 
-export const badScope = (message: string) =>
+const badScope = (message: string) =>
   new AppError({
     code: "BAD_REQUEST",
     applicationCode: "knowledge.invalid_scope",

--- a/apps/app/src/features/knowledge/server/topic-view.ts
+++ b/apps/app/src/features/knowledge/server/topic-view.ts
@@ -18,7 +18,7 @@ export const TOPIC_SELECT = {
   },
 } as const;
 
-export type StoredTopic = Prisma.KnowledgeTopicGetPayload<{
+type StoredTopic = Prisma.KnowledgeTopicGetPayload<{
   select: typeof TOPIC_SELECT;
 }>;
 

--- a/apps/app/src/features/knowledge/topic-screen.tsx
+++ b/apps/app/src/features/knowledge/topic-screen.tsx
@@ -1,0 +1,65 @@
+import type { KnowledgeTranslations, TopicLanguage } from "./contracts";
+
+import { hasAppErrorCode } from "@scibly/api/application-error";
+import { getLocale } from "@scibly/i18n";
+import { notFound } from "next/navigation";
+import { connection } from "next/server";
+import { Suspense } from "react";
+
+import { getFullDictionary } from "@/i18n/dictionaries";
+import { api, HydrateClient } from "@/shared/api/trpc/server";
+
+import { TopicDetailClient } from "./components/topic-detail-client";
+import { TopicsSkeleton } from "./components/topics-skeleton";
+
+async function Topic({
+  t,
+  orgSlug,
+  topicId,
+  defaultLanguage,
+}: {
+  t: KnowledgeTranslations;
+  orgSlug: string;
+  topicId: string;
+  defaultLanguage: TopicLanguage;
+}) {
+  // Dehydrating the topic reads the clock, so this subtree is explicitly the streamed one rather than part of the shell.
+  await connection();
+  try {
+    await api.knowledge.get.prefetch({ orgSlug, topicId });
+  } catch (error) {
+    if (hasAppErrorCode(error, "NOT_FOUND", "FORBIDDEN")) notFound();
+    throw error;
+  }
+
+  return (
+    <HydrateClient>
+      <TopicDetailClient
+        t={t}
+        orgSlug={orgSlug}
+        topicId={topicId}
+        defaultLanguage={defaultLanguage}
+      />
+    </HydrateClient>
+  );
+}
+
+export async function KnowledgeTopicScreen(props: {
+  params: Promise<{ lang: string; orgSlug: string; topicId: string }>;
+}) {
+  const { lang, orgSlug, topicId } = await props.params;
+  const t = (await getFullDictionary(lang)).knowledge;
+
+  return (
+    <div className="flex w-full flex-col gap-8 pb-20">
+      <Suspense fallback={<TopicsSkeleton />}>
+        <Topic
+          t={t}
+          orgSlug={orgSlug}
+          topicId={topicId}
+          defaultLanguage={getLocale(lang, true)}
+        />
+      </Suspense>
+    </div>
+  );
+}

--- a/apps/app/src/features/notebook/sources/provider-display.ts
+++ b/apps/app/src/features/notebook/sources/provider-display.ts
@@ -1,15 +1,7 @@
-import type React from "react";
+import type { ComponentType } from "react";
 import type { PageIntegrationProviderId } from "@/features/integrations/contracts";
 
 import { NotionLogoIcon } from "@radix-ui/react-icons";
-
-interface ProviderDisplayConfig {
-  readonly name: string;
-
-  readonly subtitle: string;
-
-  readonly Logo: React.ComponentType<{ className?: string }>;
-}
 
 export const PROVIDER_DISPLAY = {
   NOTION: {
@@ -17,4 +9,11 @@ export const PROVIDER_DISPLAY = {
     subtitle: "Browse your Notion workspace and add pages as sources",
     Logo: NotionLogoIcon,
   },
-} satisfies Record<PageIntegrationProviderId, ProviderDisplayConfig>;
+} satisfies Record<
+  PageIntegrationProviderId,
+  {
+    name: string;
+    subtitle: string;
+    Logo: ComponentType<{ className?: string }>;
+  }
+>;

--- a/apps/app/src/server/inngest.ts
+++ b/apps/app/src/server/inngest.ts
@@ -2,5 +2,14 @@ import {
   integrationPoll,
   integrationSync,
 } from "@/features/integrations/server";
+import {
+  knowledgeCollect,
+  knowledgeCollectionSync,
+} from "@/features/knowledge/server";
 
-export const inngestFunctions = [integrationSync, integrationPoll];
+export const inngestFunctions = [
+  integrationSync,
+  integrationPoll,
+  knowledgeCollectionSync,
+  knowledgeCollect,
+];

--- a/apps/app/src/shared/ai/token-estimate.ts
+++ b/apps/app/src/shared/ai/token-estimate.ts
@@ -1,8 +1,5 @@
-// A single ratio stands in for tokenization since organizations bring their own
-// endpoints and no per-model tokenizer is available; downstream consumers
-// budget well inside the real window, so the approximation error is absorbed,
-// not paid for.
-const CHARS_PER_TOKEN = 4;
+// One flat ratio: organizations bring their own model endpoints, so no per-model tokenizer is available.
+export const CHARS_PER_TOKEN = 4;
 
 export function estimateTokens(text: string): number {
   return Math.ceil(text.length / CHARS_PER_TOKEN);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": ">=22"
+    "node": ">=22.5"
   },
   "scripts": {
     "dev": "node scripts/dev.mjs",

--- a/packages/db/migrations/20260830140000_knowledge_collection/migration.sql
+++ b/packages/db/migrations/20260830140000_knowledge_collection/migration.sql
@@ -1,0 +1,68 @@
+-- The collection stage: merged pull requests worth learning from become
+-- bundles, held for the organization against the repository they came from.
+-- A run is both the record of one repository's turn and the watermark — only a
+-- run that succeeded says how far collection has got.
+
+-- CreateEnum
+CREATE TYPE "knowledge_discard_reason" AS ENUM ('BOT_AUTHOR', 'CHORE_TITLE', 'NO_DISCUSSION', 'LOW_DENSITY');
+
+-- CreateEnum
+CREATE TYPE "knowledge_collection_run_status" AS ENUM ('QUEUED', 'RUNNING', 'SUCCEEDED', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "knowledge_collection_run" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "repositoryId" TEXT NOT NULL,
+    "status" "knowledge_collection_run_status" NOT NULL DEFAULT 'QUEUED',
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "finishedAt" TIMESTAMP(3),
+    "collected" INTEGER NOT NULL DEFAULT 0,
+    "discarded" INTEGER NOT NULL DEFAULT 0,
+    "collectedThrough" TIMESTAMP(3),
+    "capped" BOOLEAN NOT NULL DEFAULT false,
+    "failureReason" TEXT,
+
+    CONSTRAINT "knowledge_collection_run_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "knowledge_bundle" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "repositoryId" TEXT NOT NULL,
+    "externalId" TEXT NOT NULL,
+    "number" INTEGER NOT NULL,
+    "githubUpdatedAt" TIMESTAMP(3) NOT NULL,
+    "mergedAt" TIMESTAMP(3),
+    "score" INTEGER,
+    "discardReason" "knowledge_discard_reason",
+    "content" JSONB,
+    "title" TEXT,
+    "url" TEXT,
+    "filePaths" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "truncated" BOOLEAN NOT NULL DEFAULT false,
+    "collectedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "knowledge_bundle_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "knowledge_collection_run_org_repo_status_idx" ON "knowledge_collection_run"("organizationId", "repositoryId", "status", "startedAt");
+
+-- One waiting turn per repository. Partial, so history keeps as many finished
+-- runs as it likes — Prisma cannot express this index, so it lives here and as
+-- a comment on the model; keep the two in step by hand.
+CREATE UNIQUE INDEX "knowledge_collection_run_one_queued_key" ON "knowledge_collection_run"("organizationId", "repositoryId") WHERE "status" = 'QUEUED';
+
+-- CreateIndex
+CREATE UNIQUE INDEX "knowledge_bundle_org_repo_external_key" ON "knowledge_bundle"("organizationId", "repositoryId", "externalId");
+
+-- CreateIndex
+CREATE INDEX "knowledge_bundle_org_repo_collected_idx" ON "knowledge_bundle"("organizationId", "repositoryId", "collectedAt");
+
+-- AddForeignKey
+ALTER TABLE "knowledge_collection_run" ADD CONSTRAINT "knowledge_collection_run_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "knowledge_bundle" ADD CONSTRAINT "knowledge_bundle_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/schema/knowledge.prisma
+++ b/packages/db/schema/knowledge.prisma
@@ -39,3 +39,97 @@ model KnowledgeTopic {
   @@unique([organizationId, name])
   @@map("knowledge_topic")
 }
+
+/// Why the structural filter refused a pull request. Kept on the discarded row
+/// so the counts in a feed can be explained and the thresholds tuned against
+/// what actually happened rather than against a guess.
+enum KnowledgeDiscardReason {
+  BOT_AUTHOR
+  CHORE_TITLE
+  NO_DISCUSSION
+  LOW_DENSITY
+
+  @@map("knowledge_discard_reason")
+}
+
+enum KnowledgeCollectionRunStatus {
+  QUEUED
+  RUNNING
+  SUCCEEDED
+  FAILED
+
+  @@map("knowledge_collection_run_status")
+}
+
+/// One repository's turn at collecting, for one organization. Also the
+/// watermark: the newest run that succeeded says how far collection has got,
+/// so a failed run cannot advance it.
+///
+/// A partial unique index — (organizationId, repositoryId) WHERE status =
+/// 'QUEUED' — guards against stacking waiting turns. Prisma cannot express it;
+/// it lives in the migration SQL only. Keep the two in step by hand.
+model KnowledgeCollectionRun {
+  id                 String                       @id @default(cuid())
+  organizationId     String
+  organization       Organization                 @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  repositoryId       String
+  status             KnowledgeCollectionRunStatus @default(QUEUED)
+  /// Written by the trigger, before the worker has picked the run up.
+  startedAt          DateTime                     @default(now())
+  finishedAt         DateTime?
+  collected          Int                          @default(0)
+  discarded          Int                          @default(0)
+  /// How recently a pull request had to have been touched to be seen by this
+  /// run. Only ever read off a SUCCEEDED run — that is what makes the watermark
+  /// advance on success alone.
+  collectedThrough   DateTime?
+  /// The run stopped on its detail budget, not on running out of pull requests.
+  /// The next run continues from `collectedThrough`.
+  capped             Boolean                      @default(false)
+  /// GitHub's own message, never a credential — see the provider's error handling.
+  failureReason      String?
+
+  @@index([organizationId, repositoryId, status, startedAt], map: "knowledge_collection_run_org_repo_status_idx")
+  @@map("knowledge_collection_run")
+}
+
+/// One merged pull request worth learning from, held for the organization
+/// against the repository it came from — never for one topic, since the same
+/// pull request feeds every topic watching that repository.
+model KnowledgeBundle {
+  id             String                  @id @default(cuid())
+  organizationId String
+  organization   Organization            @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  repositoryId   String
+  /// GitHub's node id for the pull request. With the repository it is what
+  /// makes a re-run a no-op.
+  externalId     String
+  number         Int
+  /// GitHub's `updatedAt`, which is what the watermark is measured in.
+  githubUpdatedAt DateTime
+  /// Null on a discarded row: nothing about a refused pull request is kept
+  /// beyond what proves it was judged.
+  mergedAt       DateTime?
+  /// The structural filter's discussion-density score. Set on a survivor, and
+  /// on a LOW_DENSITY discard so the threshold can be tuned against real numbers.
+  score          Int?
+  /// Set exactly when `content` is null.
+  discardReason  KnowledgeDiscardReason?
+  /// `{ title, body, labels, filePaths, linkedIssues, threads }` — sanitized and
+  /// token-capped before it is written. Pruned back to null by the extraction
+  /// stage once the bundle has been read.
+  content        Json?
+  /// What the feed shows, lifted out of `content` so reading it never means
+  /// hauling the whole conversation. Null exactly when `content` is.
+  title          String?
+  url            String?
+  filePaths      String[]                @default([])
+  /// The token cap dropped something, so nothing downstream may claim the
+  /// bundle is the whole conversation.
+  truncated      Boolean                 @default(false)
+  collectedAt    DateTime                @default(now())
+
+  @@unique([organizationId, repositoryId, externalId], map: "knowledge_bundle_org_repo_external_key")
+  @@index([organizationId, repositoryId, collectedAt], map: "knowledge_bundle_org_repo_collected_idx")
+  @@map("knowledge_bundle")
+}

--- a/packages/db/schema/organization.prisma
+++ b/packages/db/schema/organization.prisma
@@ -23,6 +23,8 @@ model Organization {
   creditLedgerEntries  CreditLedgerEntry[]
   courseEnrollments    CourseEnrollment[]
   knowledgeTopics      KnowledgeTopic[]
+  knowledgeBundles     KnowledgeBundle[]
+  knowledgeCollectionRuns KnowledgeCollectionRun[]
 
   @@unique([slug])
   @@map("organization")

--- a/packages/routes/src/index.ts
+++ b/packages/routes/src/index.ts
@@ -180,6 +180,8 @@ export const routes = {
           },
           knowledge: {
             root: toAppUrl(`${baseOrgRoute}/knowledge`),
+            topic: (topicId: string) =>
+              toAppUrl(`${baseOrgRoute}/knowledge/${topicId}`),
           },
           members: {
             root: toAppUrl(`${baseOrgRoute}/members`),
@@ -226,6 +228,7 @@ export const routes = {
     integrations: {
       github: {
         api: "https://api.github.com",
+        graphql: "https://api.github.com/graphql",
         oauthToken: `${GITHUB_URL}/login/oauth/access_token` as const,
         install: (appSlug: string) =>
           `${GITHUB_URL}/apps/${encodeURIComponent(appSlug)}/installations/new` as const,

--- a/packages/schemas/src/schema/common/index.ts
+++ b/packages/schemas/src/schema/common/index.ts
@@ -1,5 +1,5 @@
 import { z } from "zod/v4";
 
 // Zod's own `.url()` accepts any scheme — `javascript:` and `data:` included — so it is a shape check, not a safety check.
-export const httpsUrl = (message = "Must be a valid https:// URL") =>
-  z.url({ protocol: /^https$/, message });
+export const httpsUrl = () =>
+  z.url({ protocol: /^https$/, message: "Must be a valid https:// URL" });

--- a/packages/ui/src/components/language-switcher/index.tsx
+++ b/packages/ui/src/components/language-switcher/index.tsx
@@ -39,7 +39,6 @@ export default function LanguageSwitcher() {
     }, 150);
   };
 
-  // A locale switch is a full navigation, so a pending close would set state on a component that is already gone.
   useEffect(
     () => () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current);


### PR DESCRIPTION
Closes #13.

Collection is the first half of the knowledge sync: merged pull requests in, filtered and sanitized bundles out. Nothing reads the bundles yet — extraction is #14.

## What runs

A daily cron and the "Sync now" button both fan out one Inngest event per repository, so a repository is the unit of work, retries and concurrency. Per-organization concurrency is capped, which is what stops one organization's backlog starving another's. Runs, retries and failure reasons show up in the Inngest dashboard and in the topic's activity feed.

## What gets kept

A structural filter refuses bots, chore titles and pull requests nobody talked on, all from the cheap listing — a detail call is only spent on a pull request that might survive. Every threshold it judges by lives in one `FILTER` object in `structural-filter.ts`; tuning the funnel is editing that object and nothing else. Survivors are stored sanitized and token-capped, with diff hunks attached to the threads they belong to and a `truncated` flag so nothing downstream can claim a bundle is the whole conversation.

## Why a re-run is free

The watermark is read off the newest run that **succeeded**, so a failed run leaves it exactly where it was and the next run covers the gap rather than skipping it. Within a run, a pull request whose `updatedAt` has not moved is recognised from the bundle table and skipped without a detail call — a sync with no new merges costs one listing.

The first run for a repository plants the watermark and collects nothing: a repository's whole history is not what "Sync now" asked for. Seeding a topic from history is #16.

## Access

A member reads the topic and its feed. Only an admin, an owner, or one of the topic's own maintainers may spend GitHub's rate limit on a sync. The gate is server-side; the hidden button is a courtesy, not the rule.

## Verification

- 32/32 typecheck / lint / format tasks green; 2741 tests passing
- Filter rules covered by fixture pull requests (bot, chore, discussion-rich)
- Live-DB harness (9 tests, gated on `E2E_DATABASE_URL`) exercises the watermark and idempotence against real Postgres
- Run end to end against a real GitHub App installation with the Inngest dev server: events published, function executed, run row and feed updated

## Known gap

No merged pull request has yet been collected from real GitHub — every live run was either the first-run watermark plant or a deliberate failure. The GraphQL listing and detail path is covered by unit tests against mocked responses, and the bundle-link rows in the topic detail have not rendered with real data. Worth one back-dated-watermark run before this stack merges to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
