### PR TITLE
refactor(mcp): drop the boundary key filter by deleting the keys

### DIFF
--- a/apps/app/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/apps/app/src/app/.well-known/oauth-authorization-server/route.ts
@@ -1,6 +1,14 @@
 import { auth } from "@scibly/auth/config";
 import { oAuthDiscoveryMetadata } from "better-auth/plugins";
+import { connection } from "next/server";
+
+const metadata = oAuthDiscoveryMetadata(auth);
 
 // MCP clients look for this at the site root, but better-auth serves it under
 // its own base path; this re-publishes it where the spec says to look.
-export const GET = oAuthDiscoveryMetadata(auth);
+export async function GET(request: Request) {
+  // Serve per request, never prerender: better-auth refuses to run in a build
+  // that has no BETTER_AUTH_SECRET, and the metadata names the live origin.
+  await connection();
+  return metadata(request);
+}

--- a/apps/app/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/apps/app/src/app/.well-known/oauth-protected-resource/route.ts
@@ -1,4 +1,10 @@
 import { auth } from "@scibly/auth/config";
 import { oAuthProtectedResourceMetadata } from "better-auth/plugins";
+import { connection } from "next/server";
 
-export const GET = oAuthProtectedResourceMetadata(auth);
+const metadata = oAuthProtectedResourceMetadata(auth);
+
+export async function GET(request: Request) {
+  await connection();
+  return metadata(request);
+}

--- a/apps/app/src/features/course-authoring/scenes/api/scene.schema.ts
+++ b/apps/app/src/features/course-authoring/scenes/api/scene.schema.ts
@@ -12,8 +12,6 @@ const sourceIdsSchema = z
 
 export const getLessonScenesSchema = z.object({
   lessonId: z.string(),
-
-  courseVersionId: z.string().optional(),
 });
 
 export const updateSceneSchema = z.object({
@@ -21,12 +19,6 @@ export const updateSceneSchema = z.object({
   updates: updateSceneUpdatesSchema
     .optional()
     .describe("Metadata updates like title, vibe, animation, sp, etc."),
-  html: z
-    .string()
-    .optional()
-    .describe(
-      "Optional HTML string to replace the scene content. Must conform to the editor schema (call get_editor_schema first). Fully replaces existing content.",
-    ),
 });
 
 export const createSceneSchema = z.object({
@@ -36,12 +28,6 @@ export const createSceneSchema = z.object({
     .optional()
     .describe(
       "The title of the scene. Defaults to 'New Scene' if not provided.",
-    ),
-  html: z
-    .string()
-    .optional()
-    .describe(
-      "Optional HTML string to initialize the scene content. Must conform to the editor schema (call get_editor_schema first). Replaces any existing content.",
     ),
   sourceIds: sourceIdsSchema.optional(),
 });

--- a/apps/app/src/features/course-authoring/scenes/server/scene-content.test.ts
+++ b/apps/app/src/features/course-authoring/scenes/server/scene-content.test.ts
@@ -82,44 +82,17 @@ describe("writing scene content", () => {
 });
 
 describe("updating a scene", () => {
-  it("sends content through the writer rather than writing the row behind the open editor", async () => {
-    await updateDraftScene(USER, {
-      sceneId: "scene_1",
-      html: "<p>Drafted.</p>",
-      updates: { title: "Intro" },
-    });
-
-    expect(writeSceneHtml).toHaveBeenCalledOnce();
-    expect(db.scene.update).toHaveBeenCalledWith({
-      where: { id: "scene_1" },
-      data: { title: "Intro", integration: undefined },
-    });
-  });
-
-  it("leaves the metadata untouched when the content is refused", async () => {
-    writeSceneHtml.mockResolvedValue({
-      success: false,
-      error: "Unknown block type(s): quiz.",
-      refused: true,
-    });
-
-    await expect(
-      updateDraftScene(USER, {
-        sceneId: "scene_1",
-        html: "<div/>",
-        updates: { title: "Intro" },
-      }),
-    ).rejects.toThrow();
-    expect(db.scene.update).not.toHaveBeenCalled();
-  });
-
-  it("a metadata-only update touches no content at all", async () => {
+  it("writes metadata and never content — that is writeSceneContent's job", async () => {
     await updateDraftScene(USER, {
       sceneId: "scene_1",
       updates: { title: "Intro" },
     });
 
     expect(writeSceneHtml).not.toHaveBeenCalled();
+    expect(db.scene.update).toHaveBeenCalledWith({
+      where: { id: "scene_1" },
+      data: { title: "Intro", integration: undefined },
+    });
   });
 
   it("clearing an integration writes a database null, not a missing field", async () => {

--- a/apps/app/src/features/course-authoring/scenes/server/scene-content.ts
+++ b/apps/app/src/features/course-authoring/scenes/server/scene-content.ts
@@ -26,18 +26,9 @@ export async function updateDraftScene(
       sp?: number;
       integration?: SceneIntegration | null;
     };
-    html?: string;
   },
 ) {
   const scene = await requireDraftSceneContentAccess(input.sceneId, user.id);
-
-  // While an author has the scene open the live collab document is
-  // authoritative and `documentState` only its stale flush target, so writing
-  // the row directly would lose either this write or the author's.
-  if (input.html !== undefined) {
-    await applySceneHtml(user, input.sceneId, input.html, "replace");
-  }
-
   const { integration, ...scalarUpdates } = input.updates ?? {};
   const updated = await db.scene.update({
     where: { id: input.sceneId },

--- a/apps/app/src/features/course-authoring/scenes/server/scene-mutations.ts
+++ b/apps/app/src/features/course-authoring/scenes/server/scene-mutations.ts
@@ -10,10 +10,6 @@ import { requireOrgMember } from "@/features/organizations/server";
 import { DEFAULT_SCENE_SP } from "@/shared/content/learning/scene-sp";
 
 import { getNextDraftSceneOrder } from "../../ordering/server/ordering";
-import {
-  parseSceneHtml,
-  SceneHtmlError,
-} from "../editor/document-synchronization/server/scene-html";
 import { requireDraftLesson } from "./scene-access";
 import { mapAuthoringScene } from "./scene-mapping";
 
@@ -22,12 +18,10 @@ export async function createDraftScene(
   input: {
     lessonId: string;
     title?: string;
-    html?: string;
     sourceIds?: string[];
   },
 ) {
   const lesson = await requireDraftLesson(db, input.lessonId, userId);
-  if (input.html !== undefined) assertSceneHtml(input.html);
   const newScene = await db.$transaction(async (tx) => {
     const order = await getNextDraftSceneOrder(tx, input.lessonId);
     return tx.scene.create({
@@ -38,7 +32,7 @@ export async function createDraftScene(
         vibe: SceneVibe.NEUTRAL,
         animation: SceneAnimation.FADE,
         sp: DEFAULT_SCENE_SP,
-        documentState: Buffer.from(encodeHtmlBytes(input.html ?? "<p></p>")),
+        documentState: Buffer.from(encodeHtmlBytes("<p></p>")),
       },
     });
   });
@@ -47,23 +41,6 @@ export async function createDraftScene(
     await sceneLineageService.replaceLineage(newScene.id, input.sourceIds);
   }
   return { ...mapAuthoringScene(newScene), courseId: lesson.courseId };
-}
-
-/**
- * The stored HTML is the seed the collab room parses on first open, and that
- * parse silently drops whatever the schema does not accept — refuse it here instead.
- */
-function assertSceneHtml(html: string) {
-  try {
-    parseSceneHtml(html);
-  } catch (error) {
-    if (!(error instanceof SceneHtmlError)) throw error;
-    throw new AppError({
-      code: "BAD_REQUEST",
-      applicationCode: "api.bad_request",
-      message: error.message,
-    });
-  }
 }
 
 async function loadCloneSource(sceneId: string) {

--- a/apps/app/src/features/course-authoring/scenes/server/scene-queries.ts
+++ b/apps/app/src/features/course-authoring/scenes/server/scene-queries.ts
@@ -1,12 +1,11 @@
 import { AppError } from "@scibly/api/application-error";
-import { db, toMemberRole } from "@scibly/db";
+import { db } from "@scibly/db";
 import { isRawHtmlState } from "@scibly/lib/collab-yjs";
 
 import { sceneLineageService } from "@/features/course-authoring/scenes/server/scene-lineage";
 import { requireOrgMember } from "@/features/organizations/server";
 import { normalizeAuthorTipTapContent } from "@/shared/content/editor/server";
 
-import { requireCourseEnrollment } from "../../access/server/policy";
 import {
   readSceneHtml,
   type SceneUser,
@@ -20,7 +19,7 @@ import { mapAuthoringScene } from "./scene-mapping";
 
 export async function listLessonScenes(
   userId: string,
-  input: { lessonId: string; courseVersionId?: string },
+  input: { lessonId: string },
 ) {
   const lesson = await db.lesson.findUnique({
     where: { id: input.lessonId },
@@ -33,28 +32,15 @@ export async function listLessonScenes(
       message: "Lesson not found.",
     });
   }
-  if (input.courseVersionId) {
-    const membership = await requireOrgMember(
-      lesson.course.organizationId,
-      userId,
-      "member",
-    );
-    await requireCourseEnrollment(
-      lesson.courseId,
-      userId,
-      toMemberRole(membership.role),
-    );
-  } else {
-    await requireOrgMember(
-      lesson.course.organizationId,
-      userId,
-      "admin_or_owner",
-    );
-  }
+  await requireOrgMember(
+    lesson.course.organizationId,
+    userId,
+    "admin_or_owner",
+  );
   const scenes = await db.scene.findMany({
     where: {
       lessonId: input.lessonId,
-      courseVersionId: input.courseVersionId ?? null,
+      courseVersionId: null,
     },
     orderBy: { order: "asc" },
     include: {

--- a/apps/app/src/features/course-authoring/server.ts
+++ b/apps/app/src/features/course-authoring/server.ts
@@ -40,6 +40,7 @@ export {
 } from "./lessons/server/lessons";
 export { publishCourse } from "./publishing/server/publish-course";
 export { publishCourseSnapshot } from "./publishing/server/publish-course-snapshot";
+export { createSceneSchema } from "./scenes/api/scene.schema";
 export { writeSceneHtml } from "./scenes/editor/document-synchronization/server/scene-document";
 export {
   getOutdatedScenes,

--- a/apps/app/src/features/mcp/server/handler.ts
+++ b/apps/app/src/features/mcp/server/handler.ts
@@ -73,7 +73,7 @@ export async function handleMcpRequest(
       {
         description:
           typeof tool.description === "string" ? tool.description : undefined,
-        inputSchema: mcpToolInput(tool.inputSchema),
+        inputSchema: mcpToolInput(name, tool.inputSchema),
       },
       async (args) => {
         const output = await execute(args, {

--- a/apps/app/src/features/mcp/server/tool-surface.ts
+++ b/apps/app/src/features/mcp/server/tool-surface.ts
@@ -2,6 +2,8 @@ import type { buildToolRegistry } from "@/features/notebook/server";
 
 import { z } from "zod";
 
+import { createSceneSchema } from "@/features/course-authoring/server";
+
 /** Deletes never join this list: the in-app confirmation gate has no MCP equivalent. */
 export const MCP_TOOL_NAMES = [
   "createCourse",
@@ -30,22 +32,17 @@ export const MCP_TOOL_NAMES = [
   ReturnType<typeof buildToolRegistry>
 >)[];
 
-// `sourceIds` never crosses the boundary (ADR 0005), `html` goes through
-// `insertContent` instead, and `courseVersionId` names a published version
-// while this surface is draft-only.
-const UNREACHABLE_KEYS = ["html", "sourceIds", "courseVersionId"];
-
-export function mcpToolInput(inputSchema: unknown) {
+export function mcpToolInput(
+  name: (typeof MCP_TOOL_NAMES)[number],
+  inputSchema: unknown,
+): z.ZodObject {
   if (!(inputSchema instanceof z.ZodObject)) {
     throw new Error("An MCP tool must declare a zod object input schema.");
   }
-
-  // eslint-disable-next-line anti-slop/no-shape-in-symbol-names -- zod owns this property name; only our alias is ours to pick.
-  const fields: Record<string, z.ZodType> = inputSchema.shape;
-
-  return z.object(
-    Object.fromEntries(
-      Object.entries(fields).filter(([key]) => !UNREACHABLE_KEYS.includes(key)),
-    ),
-  );
+  // An external agent has no notebook, so any lineage it cited would be
+  // fiction (ADR 0005). `.omit` is checked against the schema, so renaming the
+  // field breaks the build instead of silently re-opening it.
+  return name === "createScene"
+    ? createSceneSchema.omit({ sourceIds: true })
+    : inputSchema;
 }


### PR DESCRIPTION
The MCP surface reuses the in-app tool schemas, and filtered three keys out at
the boundary with a list of name strings:

```ts
const UNREACHABLE_KEYS = ["html", "sourceIds", "courseVersionId"];
```

Two of those three had no in-app caller either, so the filter was covering for
dead fields rather than for a real boundary difference.

## `html` on `createScene` / `updateScene`

Both tool descriptions already told the model these are metadata-only and that
content goes through `insertContent`, so the field contradicted its own docs.
Removed from the schemas, which made `assertSceneHtml` and the `applySceneHtml`
branch in `updateDraftScene` dead.

## `courseVersionId` on `getLessonScenes`

No caller has ever passed it — the three UI call sites pass `{ lessonId }`, and
the learner path reads published scenes through `learner-course.ts` /
`preview-scene.ts`. Its `if` branch in `listLessonScenes` (enrolled-learner auth
for published scenes) was unreachable, so it went with the field.

## `sourceIds` stays omitted, but typed

ADR 0005 stands: an external agent has no notebook, so any lineage it cited
would be fiction. That one omission is now a checked expression instead of a
string:

```ts
return name === "createScene"
  ? createSceneSchema.omit({ sourceIds: true })
  : inputSchema;
```

`name` is checked against `MCP_TOOL_NAMES` and `sourceIds` against
`createSceneSchema`'s real shape, so renaming either breaks the build instead of
silently re-opening the field.

## Verification

Typecheck, lint and 2,668 unit tests green. The three MCP boundary tests are
unchanged and still pass — `html` appears only on `insertContent`, no tool names
`sourceIds`, and smuggled keys are discarded. They now hold because the fields
do not exist rather than because a filter caught them.

## Behaviour note for review

Deleting `courseVersionId` removed a live authorization branch that let enrolled
members read published scenes via `listLessonScenes`. Nothing reached it, but it
is the one deletion here that was not already dead by contract — say so if you
would rather keep that path parked.

Net -89 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)