### PR TITLE
added tool approval fallback to work in claude, chatgpt etc.

### DIFF
--- a/apps/app/src/features/mcp/server/approval.test.ts
+++ b/apps/app/src/features/mcp/server/approval.test.ts
@@ -1,11 +1,19 @@
 // @vitest-environment node
+import type { McpServer } from "@modelcontextprotocol/server";
+
 import {
   CLIENT_CAPABILITIES_META_KEY,
   isInputRequiredResult,
 } from "@modelcontextprotocol/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 
-import { approval, type ApprovalRefusals, approvalToken } from "./approval";
+import {
+  approval,
+  type ApprovalRefusals,
+  approvalToken,
+  registerApprovedTool,
+} from "./approval";
 
 const REFUSALS: ApprovalRefusals = {
   cancelled: "no answer",
@@ -31,6 +39,11 @@ function ctx(answer?: {
   } as never;
 }
 
+/** A 2025-era client: no capability envelope reaches the handler at all. */
+const LEGACY = {
+  mcpReq: { inputResponses: undefined, requestState: () => undefined },
+} as never;
+
 function ask(answer?: Parameters<typeof ctx>[0]) {
   return approval(ctx(answer), {
     token: TOKEN,
@@ -39,11 +52,22 @@ function ask(answer?: Parameters<typeof ctx>[0]) {
   });
 }
 
+function askLegacy(confirmationToken?: string) {
+  return approval(LEGACY, {
+    token: TOKEN,
+    message: "Delete two scenes?",
+    refusals: REFUSALS,
+    confirmationToken,
+  });
+}
+
 function refusal(result: ReturnType<typeof ask>) {
   const content = (result as { content?: { text: string }[] }).content;
   return JSON.parse(content![0]!.text) as {
     success: boolean;
     message: string;
+    needsConfirmation?: boolean;
+    confirmationToken?: string;
   };
 }
 
@@ -116,6 +140,42 @@ describe("the approval gate", () => {
   });
 });
 
+describe("the approval gate on a client that cannot be elicited", () => {
+  it("A8: hands back the same summary and the token that opens it, having done nothing", () => {
+    const answer = refusal(askLegacy());
+
+    expect(answer.success).toBe(false);
+    expect(answer.needsConfirmation).toBe(true);
+    expect(answer.confirmationToken).toBe(TOKEN);
+    expect(answer.message).toContain("Delete two scenes?");
+  });
+
+  it("A8: lets the second call through on the token it issued", () => {
+    expect(askLegacy(TOKEN)).toBeNull();
+  });
+
+  it("A9: a token minted for another set of items does not open this one", () => {
+    const result = askLegacy(approvalToken("deleteScenes", "course-1", ["c"]));
+
+    expect(refusal(result).message).toBe(REFUSALS.mismatched);
+  });
+
+  it("A9: nor does an empty one, which is a token echoed back wrong rather than absent", () => {
+    expect(refusal(askLegacy("")).message).toBe(REFUSALS.mismatched);
+  });
+
+  it("A10: a client that can elicit is still elicited, token or no token", () => {
+    const result = approval(ctx(), {
+      token: TOKEN,
+      message: "Delete two scenes?",
+      refusals: REFUSALS,
+      confirmationToken: TOKEN,
+    });
+
+    expect(isInputRequiredResult(result)).toBe(true);
+  });
+});
+
 describe("approvalToken", () => {
   it("A6: does not care what order the caller listed the items in", () => {
     expect(approvalToken("deleteScenes", "course-1", ["b", "a"])).toBe(TOKEN);
@@ -135,5 +195,107 @@ describe("approvalToken", () => {
     expect(approvalToken("deleteScenes", "course-1", ['a","b'])).not.toBe(
       TOKEN,
     );
+  });
+});
+
+describe("registerApprovedTool", () => {
+  type Registered = {
+    description: string;
+    inputSchema: z.ZodObject;
+  };
+
+  type Args = { courseId: string; confirmationToken?: string };
+
+  function register(name: string) {
+    let config!: Registered;
+    let callback!: (args: never, ctx: never) => Promise<unknown>;
+    const ran = vi.fn(async () => ({ success: true }));
+
+    registerApprovedTool(
+      {
+        registerTool: (_name: string, cfg: Registered, cb: typeof callback) => {
+          config = cfg;
+          callback = cb;
+        },
+      } as unknown as McpServer,
+      {
+        name,
+        description: "Does a thing.",
+        inputSchema: z.object({ courseId: z.string() }),
+        undone: "nothing changed",
+      },
+      async ({ courseId }) => ({
+        courseId,
+        ids: ["a"],
+        message: "Do the thing?",
+        run: ran,
+      }),
+    );
+
+    const call = (args: Args) =>
+      callback(
+        args as never,
+        {
+          mcpReq: { inputResponses: undefined, requestState: () => undefined },
+        } as never,
+      ) as Promise<{ content: { text: string }[] }>;
+
+    return { config, call, ran };
+  }
+
+  async function output(result: Promise<{ content: { text: string }[] }>) {
+    return JSON.parse((await result).content[0]!.text) as {
+      success: boolean;
+      needsConfirmation?: boolean;
+      confirmationToken?: string;
+    };
+  }
+
+  it("A11: teaches every gated tool the two-call protocol in one wording", () => {
+    const { config } = register("doThing");
+
+    expect(config.description).toContain("Does a thing.");
+    expect(config.description).toContain("needsConfirmation:true");
+    expect(
+      config.inputSchema.safeParse({
+        courseId: "course-1",
+        confirmationToken: "t",
+      }).data,
+    ).toEqual({ courseId: "course-1", confirmationToken: "t" });
+  });
+
+  it("A11: mints the token from the registered name, so no tool opens another's gate", async () => {
+    const mine = register("doThing");
+    const other = register("doOtherThing");
+
+    const asked = await output(mine.call({ courseId: "course-1" }));
+    expect(asked.confirmationToken).toBe(
+      approvalToken("doThing", "course-1", ["a"]),
+    );
+
+    const crossed = await output(
+      other.call({
+        courseId: "course-1",
+        confirmationToken: asked.confirmationToken,
+      }),
+    );
+    expect(crossed.success).toBe(false);
+    expect(other.ran).not.toHaveBeenCalled();
+  });
+
+  it("A11: runs the work only once the token comes back", async () => {
+    const { call, ran } = register("doThing");
+
+    const asked = await output(call({ courseId: "course-1" }));
+    expect(ran).not.toHaveBeenCalled();
+
+    const done = await output(
+      call({
+        courseId: "course-1",
+        confirmationToken: asked.confirmationToken,
+      }),
+    );
+    expect(done.success).toBe(true);
+    expect(ran).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/app/src/features/mcp/server/approval.ts
+++ b/apps/app/src/features/mcp/server/approval.ts
@@ -1,6 +1,9 @@
 import type {
+  CallToolResult,
   ClientCapabilities,
+  McpServer,
   ServerContext,
+  ToolAnnotations,
 } from "@modelcontextprotocol/server";
 
 import {
@@ -22,42 +25,84 @@ export type ApprovalRefusals = {
   mismatched: string;
 };
 
+/**
+ * The three ways an author says no, in one wording.
+ *
+ * `undone` completes "…, so nothing was deleted". It names what did not
+ * happen, in the tense the tool would have reported it.
+ */
+export function refusals(undone: string): ApprovalRefusals {
+  return {
+    cancelled: `The author did not answer; ${undone}. Ask again if this still needs doing.`,
+    declined: `The author declined. ${undone[0]!.toUpperCase()}${undone.slice(1)}.`,
+    mismatched:
+      `This approval was given for a different request, so ${undone}. ` +
+      "Call the tool again with what you actually mean, and the author will be asked about that.",
+  };
+}
+
 export function approvalToken(
   tool: string,
   courseId: string,
   ids: readonly string[],
 ): string {
-  // JSON, not `join`: an id containing the separator must not re-cut into a different set.
+  // JSON, not `join`. An id containing the separator would otherwise re-cut
+  // into a different set.
   return JSON.stringify([tool, courseId, [...ids].sort()]);
 }
+
+const confirmationTokenSchema = z
+  .string()
+  .optional()
+  .describe(
+    "Only ever the exact confirmationToken this tool handed back on a previous call, and only once the author has approved that summary. " +
+      "Leave it out on a first call, and never write one yourself.",
+  );
+
+const APPROVAL_NOTE =
+  "The author approves before anything happens, and the tool runs that approval — call it rather than composing your own warning. " +
+  "A client that can show a dialog gets one. A client that cannot gets back success:false with needsConfirmation:true, the summary to put in front of the author word for word, and a confirmationToken to send on an otherwise identical second call once they have said yes. " +
+  "A refusal comes back as success:false without needsConfirmation; that is an answer, not a failure, so do not call again.";
+
+const CONFIRM_NOTE =
+  "Show the author this exact summary and ask them. If they say yes, call the tool again with the same arguments plus the confirmationToken below. If they say no, stop.";
 
 export type ApprovalRequest = {
   token: string;
   message: string;
   refusals: ApprovalRefusals;
+  /** What the caller passed back; `undefined` on a first call. */
+  confirmationToken?: string;
 };
 
-const UNASKABLE =
-  "This client cannot be asked to show the author an approval, and the author's approval is required, so nothing was done. " +
-  "Tell the author to do it in Scibly themselves, or to connect a client that supports elicitation on MCP revision 2026-07-28. Calling again will not help.";
-
-/** A result means the tool is done — asking or refusing; `null` means go. */
+/** A result means the tool is done, asking or refusing. `null` means go. */
 export function approval(
   ctx: ServerContext,
-  { token, message, refusals }: ApprovalRequest,
+  { token, message, refusals, confirmationToken }: ApprovalRequest,
 ): ReturnType<typeof inputRequired> | ReturnType<typeof text> | null {
   const answer = inputResponse(ctx.mcpReq.inputResponses, "confirm");
 
   if (answer.kind !== "elicit") {
     // Capabilities reach a per-request handler only in the 2026-07-28 `_meta`
-    // envelope, so a 2025-era client cannot be asked at all (ADR 0006).
+    // envelope, and the 2025-era leg we also serve is stateless. Such a client
+    // cannot be elicited at all, so it confirms over two calls (ADR 0006).
     // SAFETY: the SDK validates the envelope before dispatch; the cast only
     // restores the key type its published `{}` alias lost.
     const envelope = ctx.mcpReq.envelope as
       | Record<string, ClientCapabilities | undefined>
       | undefined;
     if (!envelope?.[CLIENT_CAPABILITIES_META_KEY]?.elicitation) {
-      return text({ success: false, message: UNASKABLE });
+      if (confirmationToken === undefined) {
+        return text({
+          success: false,
+          needsConfirmation: true,
+          message: `${message}\n\n${CONFIRM_NOTE}`,
+          confirmationToken: token,
+        });
+      }
+      return confirmationToken === token
+        ? null
+        : text({ success: false, message: refusals.mismatched });
     }
 
     return inputRequired({
@@ -84,4 +129,82 @@ export function approval(
   }
 
   return null;
+}
+
+/** What a tool reports once its work is done. Extra fields go into the JSON too. */
+export type ToolOutcome = { success: boolean };
+
+/** What a tool decided to do, once the author approves it. */
+export type Approvable = {
+  courseId: string;
+  /** What the approval binds to within the course; omitted when the course itself is the subject. */
+  ids?: readonly string[];
+  /** The summary the author reads, in a dialog or in the client's own words. */
+  message: string;
+  run: () => Promise<ToolOutcome>;
+};
+
+/** `CallToolResult` carries an index signature, so `'run' in planned` does not narrow it away. */
+function isApprovable(
+  planned: Approvable | CallToolResult,
+): planned is Approvable {
+  // SAFETY: reading one property off the union to test it. The predicate is
+  // what turns that test into the narrowing, and a result never carries `run`.
+  return typeof (planned as Approvable).run === "function";
+}
+
+/**
+ * Registers a tool whose work waits on the author.
+ *
+ * `plan` does the reading and the refusing. It returns either a plain result,
+ * meaning it found nothing to approve, or a description of the one thing it
+ * would do. The gate, its two wordings, the `confirmationToken` field and the
+ * note teaching a caller to use it are the same for every such tool, so they
+ * live here rather than in each one.
+ */
+export function registerApprovedTool<Input extends z.ZodObject>(
+  server: McpServer,
+  config: {
+    name: string;
+    description: string;
+    inputSchema: Input;
+    annotations?: ToolAnnotations;
+    /** Completes "…, so nothing was deleted" when the author says no. */
+    undone: string;
+  },
+  plan: (
+    args: z.output<Input>,
+    ctx: ServerContext,
+  ) => Promise<Approvable | CallToolResult>,
+): void {
+  const refused = refusals(config.undone);
+
+  server.registerTool(
+    config.name,
+    {
+      description: `${config.description} ${APPROVAL_NOTE}`,
+      inputSchema: config.inputSchema.extend({
+        confirmationToken: confirmationTokenSchema,
+      }),
+      ...(config.annotations && { annotations: config.annotations }),
+    },
+    async (raw, ctx) => {
+      // SAFETY: the SDK validated `raw` against the schema built just above, so
+      // it holds the caller's fields plus the one optional string added here.
+      // Zod's `.extend` generics do not survive `Input` to say so.
+      const args = raw as z.output<Input> & { confirmationToken?: string };
+
+      const planned = await plan(args, ctx);
+      if (!isApprovable(planned)) return planned;
+
+      const gate = approval(ctx, {
+        token: approvalToken(config.name, planned.courseId, planned.ids ?? []),
+        message: planned.message,
+        confirmationToken: args.confirmationToken,
+        refusals: refused,
+      });
+
+      return gate ?? text(await planned.run());
+    },
+  );
 }

--- a/apps/app/src/features/mcp/server/deletion-tools.test.ts
+++ b/apps/app/src/features/mcp/server/deletion-tools.test.ts
@@ -139,6 +139,7 @@ type ToolArgs = {
   sceneIds?: string[];
   lessonIds?: string[];
   reason?: string;
+  confirmationToken?: string;
 };
 
 type Tool = (args: never, ctx: unknown) => Promise<ToolResult>;
@@ -173,12 +174,23 @@ function call(
   });
 }
 
+/** A 2025-era client: no capability envelope reaches the handler at all. */
+function callLegacy(name: string, args: ToolArgs) {
+  const tool = tools.get(name);
+  if (!tool) throw new Error(`${name} was never registered`);
+  return tool(args as never, {
+    mcpReq: { inputResponses: undefined, requestState: () => undefined },
+  });
+}
+
 function output(result: ToolResult) {
   return JSON.parse(result.content![0]!.text) as {
     success: boolean;
     message: string;
     missingSceneIds?: string[];
     missingLessonIds?: string[];
+    needsConfirmation?: boolean;
+    confirmationToken?: string;
   };
 }
 
@@ -285,8 +297,8 @@ describe("deleteScenes", () => {
     expect(output(result)).toEqual({
       success: false,
       message:
-        "This approval was given for a different set of items, so nothing was deleted. " +
-        "Call the tool again with what you actually mean to remove, and the author will be asked about that.",
+        "This approval was given for a different request, so nothing was deleted. " +
+        "Call the tool again with what you actually mean, and the author will be asked about that.",
     });
   });
 
@@ -489,8 +501,8 @@ describe("deleteCourse", () => {
     expect(output(result)).toEqual({
       success: false,
       message:
-        "This approval was given for a different set of items, so nothing was deleted. " +
-        "Call the tool again with what you actually mean to remove, and the author will be asked about that.",
+        "This approval was given for a different request, so nothing was deleted. " +
+        "Call the tool again with what you actually mean, and the author will be asked about that.",
     });
   });
 
@@ -503,5 +515,77 @@ describe("deleteCourse", () => {
 
     expect(deleteCourse).not.toHaveBeenCalled();
     expect(output(result).success).toBe(false);
+  });
+});
+
+describe("a client that cannot be elicited", () => {
+  const args = { courseId: "course-1", sceneIds: ["scene-1", "scene-2"] };
+
+  it("D9: gets the same summary to put in front of the author, and nothing is deleted yet", async () => {
+    const answer = output(await callLegacy("deleteScenes", args));
+
+    expect(deleteDraftScenes).not.toHaveBeenCalled();
+    expect(answer.success).toBe(false);
+    expect(answer.needsConfirmation).toBe(true);
+    expect(answer.message).toContain(
+      'Permanently delete 2 scenes from "Photosynthesis"?',
+    );
+    expect(answer.confirmationToken).toBeTruthy();
+  });
+
+  it("D9: deletes on the second call, once the token comes back", async () => {
+    const first = output(await callLegacy("deleteScenes", args));
+    const second = await callLegacy("deleteScenes", {
+      ...args,
+      confirmationToken: first.confirmationToken,
+    });
+
+    expect(output(second).success).toBe(true);
+    expect(deleteDraftScenes).toHaveBeenCalledWith("user-1", [
+      "scene-1",
+      "scene-2",
+    ]);
+  });
+
+  it("D10: a token approved for two scenes does not delete a third", async () => {
+    const first = output(await callLegacy("deleteScenes", args));
+    const result = await callLegacy("deleteScenes", {
+      courseId: "course-1",
+      sceneIds: ["scene-1", "scene-2", "scene-3"],
+      confirmationToken: first.confirmationToken,
+    });
+
+    expect(deleteDraftScenes).not.toHaveBeenCalled();
+    expect(output(result).success).toBe(false);
+    expect(output(result).message).toContain("a different request");
+  });
+
+  it("D10: nor does one minted for another tool", async () => {
+    const first = output(await callLegacy("deleteScenes", args));
+    const result = await callLegacy("deleteLessons", {
+      courseId: "course-1",
+      lessonIds: ["lesson-1"],
+      confirmationToken: first.confirmationToken,
+    });
+
+    expect(deleteDraftLessons).not.toHaveBeenCalled();
+    expect(output(result).success).toBe(false);
+  });
+
+  it("D11: the whole-course delete is gated the same way", async () => {
+    const first = output(
+      await callLegacy("deleteCourse", { courseId: "course-1" }),
+    );
+    expect(deleteCourse).not.toHaveBeenCalled();
+    expect(first.needsConfirmation).toBe(true);
+    expect(first.message).toContain("12 enrolled learners");
+
+    const second = await callLegacy("deleteCourse", {
+      courseId: "course-1",
+      confirmationToken: first.confirmationToken,
+    });
+
+    expect(output(second).success).toBe(true);
+    expect(deleteCourse).toHaveBeenCalledWith("user-1", "course-1");
   });
 });

--- a/apps/app/src/features/mcp/server/deletion-tools.ts
+++ b/apps/app/src/features/mcp/server/deletion-tools.ts
@@ -14,21 +14,10 @@ import {
   resolveSceneDeletion,
 } from "@/features/course-authoring/server";
 
-import { approval, type ApprovalRefusals, approvalToken } from "./approval";
+import { registerApprovedTool } from "./approval";
 import { readable, text } from "./tool-response";
 
-const REFUSALS: ApprovalRefusals = {
-  cancelled:
-    "The author did not answer; nothing was deleted. Ask again if this still needs doing.",
-  declined: "The author declined. Nothing was deleted.",
-  mismatched:
-    "This approval was given for a different set of items, so nothing was deleted. " +
-    "Call the tool again with what you actually mean to remove, and the author will be asked about that.",
-};
-
-const APPROVAL_NOTE =
-  "The calling client shows the author an approval listing exactly what would go, so never ask for approval in plain text — call the tool and let it ask. " +
-  "A declined deletion comes back as success:false with nothing deleted; that is an answer, not a failure, so do not call again.";
+const UNDONE = "nothing was deleted";
 
 const reasonSchema = deletionReasonSchema
   .optional()
@@ -87,22 +76,23 @@ function withReason(lines: string[], reason: string | undefined): string {
 }
 
 export function registerDeletionTools(server: McpServer, userId: string) {
-  server.registerTool(
-    "deleteScenes",
+  registerApprovedTool(
+    server,
     {
+      name: "deleteScenes",
       description:
         "Permanently delete one or more draft scenes. " +
         "Pass every scene in one call — the author approves them together, and one approval beats five. " +
-        "Use the exact scene `id` from listScenes; a lesson cannot be emptied, so reach for deleteLessons when the whole lesson should go. " +
-        APPROVAL_NOTE,
+        "Use the exact scene `id` from listScenes; a lesson cannot be emptied, so reach for deleteLessons when the whole lesson should go.",
       inputSchema: z.object({
         courseId: z.string().describe("The course these scenes belong to."),
         sceneIds: idsSchema("scene", "listScenes"),
         reason: reasonSchema,
       }),
       annotations: { destructiveHint: true, idempotentHint: false },
+      undone: UNDONE,
     },
-    async ({ courseId, sceneIds, reason }, ctx) => {
+    async ({ courseId, sceneIds, reason }) => {
       const ids = [...new Set(sceneIds)];
       const resolved = await readable("deleteScenes", () =>
         resolveSceneDeletion(userId, ids),
@@ -121,9 +111,9 @@ export function registerDeletionTools(server: McpServer, userId: string) {
         byLesson.set(scene.lessonId, lesson);
       }
 
-      const gate = approval(ctx, {
-        token: approvalToken("deleteScenes", courseId, ids),
-        refusals: REFUSALS,
+      return {
+        courseId,
+        ids,
         message: withReason(
           [
             `Permanently delete ${plural(found.length, "scene")} from "${course.title}"? This cannot be undone.`,
@@ -135,31 +125,29 @@ export function registerDeletionTools(server: McpServer, userId: string) {
           ],
           reason,
         ),
-      });
-      if (gate) return gate;
-
-      return text(
-        await readable("deleteScenes", () => deleteDraftScenes(userId, ids)),
-      );
+        run: () =>
+          readable("deleteScenes", () => deleteDraftScenes(userId, ids)),
+      };
     },
   );
 
-  server.registerTool(
-    "deleteLessons",
+  registerApprovedTool(
+    server,
     {
+      name: "deleteLessons",
       description:
         "Permanently delete one or more lessons and every draft scene inside them. " +
         "Pass every lesson in one call — the author approves them together. " +
-        "This is also how a lesson's last scene goes: deleteScenes cannot empty a lesson. " +
-        APPROVAL_NOTE,
+        "This is also how a lesson's last scene goes: deleteScenes cannot empty a lesson.",
       inputSchema: z.object({
         courseId: z.string().describe("The course these lessons belong to."),
         lessonIds: idsSchema("lesson", "listLessons"),
         reason: reasonSchema,
       }),
       annotations: { destructiveHint: true, idempotentHint: false },
+      undone: UNDONE,
     },
-    async ({ courseId, lessonIds, reason }, ctx) => {
+    async ({ courseId, lessonIds, reason }) => {
       const ids = [...new Set(lessonIds)];
       const resolved = await readable("deleteLessons", () =>
         resolveLessonDeletion(userId, ids),
@@ -168,9 +156,9 @@ export function registerDeletionTools(server: McpServer, userId: string) {
       if (refusal) return refusal;
 
       const { course, found } = resolved!;
-      const gate = approval(ctx, {
-        token: approvalToken("deleteLessons", courseId, ids),
-        refusals: REFUSALS,
+      return {
+        courseId,
+        ids,
         message: withReason(
           [
             `Permanently delete ${plural(found.length, "lesson")} from "${course.title}"? Every scene inside goes too, and this cannot be undone.`,
@@ -182,39 +170,36 @@ export function registerDeletionTools(server: McpServer, userId: string) {
           ],
           reason,
         ),
-      });
-      if (gate) return gate;
-
-      return text(
-        await readable("deleteLessons", () =>
-          deleteDraftLessons(userId, { courseId, lessonIds: ids }),
-        ),
-      );
+        run: () =>
+          readable("deleteLessons", () =>
+            deleteDraftLessons(userId, { courseId, lessonIds: ids }),
+          ),
+      };
     },
   );
 
-  server.registerTool(
-    "deleteCourse",
+  registerApprovedTool(
+    server,
     {
+      name: "deleteCourse",
       description:
         "Permanently delete an entire course: every lesson and scene, every published version, and every enrollment with the progress attached to it. " +
-        "This is not how a draft is tidied up — reach for deleteLessons unless the whole course is meant to stop existing. " +
-        APPROVAL_NOTE,
+        "This is not how a draft is tidied up — reach for deleteLessons unless the whole course is meant to stop existing.",
       inputSchema: z.object({
         courseId: z.string().describe("The course to delete."),
         reason: reasonSchema,
       }),
       annotations: { destructiveHint: true, idempotentHint: false },
+      undone: UNDONE,
     },
-    async ({ courseId, reason }, ctx) => {
+    async ({ courseId, reason }) => {
       const course = await readable("deleteCourse", () =>
         getCourse(userId, courseId),
       );
 
       const published = course.versions[0];
-      const gate = approval(ctx, {
-        token: approvalToken("deleteCourse", courseId, []),
-        refusals: REFUSALS,
+      return {
+        courseId,
         message: withReason(
           [
             `Permanently delete the whole course "${course.title}"? This cannot be undone.`,
@@ -236,12 +221,9 @@ export function registerDeletionTools(server: McpServer, userId: string) {
           ],
           reason,
         ),
-      });
-      if (gate) return gate;
-
-      return text(
-        await readable("deleteCourse", () => deleteCourse(userId, courseId)),
-      );
+        run: () =>
+          readable("deleteCourse", () => deleteCourse(userId, courseId)),
+      };
     },
   );
 }

--- a/apps/app/src/features/mcp/server/handler.test.ts
+++ b/apps/app/src/features/mcp/server/handler.test.ts
@@ -638,16 +638,34 @@ describe("asking the author for approval over the wire", () => {
     expect(updateCourse).not.toHaveBeenCalled();
   });
 
-  it("PUB5: answers a 2025-era client in words, since it can never be asked", async () => {
-    const { body } = await post(
+  it("PUB5: walks a 2025-era client through two calls, since it can never be elicited", async () => {
+    const first = await post(
       rpc("tools/call", SET_PUBLIC),
       fakeCaller().caller,
     );
 
-    const output = JSON.parse(body.result.content[0].text);
-    expect(output.success).toBe(false);
-    expect(output.message).toContain("cannot be asked");
+    const asked = JSON.parse(first.body.result.content[0].text);
+    expect(asked.success).toBe(false);
+    expect(asked.needsConfirmation).toBe(true);
+    expect(asked.message).toContain("public");
+    expect(asked.confirmationToken).toBe(
+      JSON.stringify(["setCoursePublic", "course-1", ["true"]]),
+    );
     expect(updateCourse).not.toHaveBeenCalled();
+
+    const second = await post(
+      rpc("tools/call", {
+        ...SET_PUBLIC,
+        arguments: {
+          ...SET_PUBLIC.arguments,
+          confirmationToken: asked.confirmationToken,
+        },
+      }),
+      fakeCaller().caller,
+    );
+
+    expect(JSON.parse(second.body.result.content[0].text).success).toBe(true);
+    expect(updateCourse).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/app/src/features/mcp/server/publishing-tools.test.ts
+++ b/apps/app/src/features/mcp/server/publishing-tools.test.ts
@@ -52,7 +52,8 @@ const UNANSWERED = {
   },
 };
 
-const UNASKABLE = {
+/** A 2025-era client: no capability envelope reaches the handler at all. */
+const LEGACY = {
   mcpReq: { inputResponses: undefined, requestState: () => undefined },
 };
 
@@ -80,6 +81,8 @@ type ToolOutput = {
   html?: string;
   isPublic?: boolean;
   requestState?: string;
+  needsConfirmation?: boolean;
+  confirmationToken?: string;
 };
 
 type ToolArgs = {
@@ -87,6 +90,7 @@ type ToolArgs = {
   supersedePrevious?: boolean;
   heightPx?: number;
   isPublic?: boolean;
+  confirmationToken?: string;
 };
 
 const tools = new Map<string, Tool>();
@@ -259,16 +263,50 @@ describe("setCoursePublic", () => {
     expect(result.success).toBe(false);
   });
 
-  it("PUB5: answers a client it cannot ask, rather than opening the course anyway (ADR 0006)", async () => {
+  it("PUB5: asks a client it cannot elicit over two calls, rather than opening the course on the first (ADR 0006)", async () => {
     const result = await call(
       "setCoursePublic",
       { courseId: "course-private", isPublic: true },
-      UNASKABLE,
+      LEGACY,
     );
 
     expect(updateCourse).not.toHaveBeenCalled();
     expect(result.success).toBe(false);
-    expect(result.message).toContain("cannot be asked");
+    expect(result.needsConfirmation).toBe(true);
+    expect(result.message).toContain('Make "Onboarding" public?');
+
+    const confirmed = await call(
+      "setCoursePublic",
+      {
+        courseId: "course-private",
+        isPublic: true,
+        confirmationToken: result.confirmationToken,
+      },
+      LEGACY,
+    );
+
+    expect(confirmed.success).toBe(true);
+    expect(updateCourse).toHaveBeenCalledTimes(1);
+  });
+
+  it("PUB5: a token the author never saw this summary for changes nothing", async () => {
+    const result = await call(
+      "setCoursePublic",
+      {
+        courseId: "course-private",
+        isPublic: true,
+        confirmationToken: JSON.stringify([
+          "setCoursePublic",
+          "course-private",
+          ["false"],
+        ]),
+      },
+      LEGACY,
+    );
+
+    expect(updateCourse).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.needsConfirmation).toBeUndefined();
   });
 
   it("PUB6: does not ask about a course that is already public", async () => {

--- a/apps/app/src/features/mcp/server/publishing-tools.ts
+++ b/apps/app/src/features/mcp/server/publishing-tools.ts
@@ -15,19 +15,10 @@ import {
   EMBED_LANGUAGE_AUTO,
 } from "@/features/learning/contracts";
 
-import { approval, type ApprovalRefusals, approvalToken } from "./approval";
+import { registerApprovedTool } from "./approval";
 import { readable, text } from "./tool-response";
 
 const courseIdSchema = z.string().describe("The ID of the course.");
-
-const REFUSALS: ApprovalRefusals = {
-  cancelled:
-    "The author did not answer; nothing changed. Ask again if this still needs doing.",
-  declined: "The author declined. Nothing changed.",
-  mismatched:
-    "This approval was given for a different change, so nothing changed. " +
-    "Call the tool again with what you actually mean, and the author will be asked about that.",
-};
 
 export function registerPublishingTools(server: McpServer, userId: string) {
   server.registerTool(
@@ -119,14 +110,13 @@ export function registerPublishingTools(server: McpServer, userId: string) {
     },
   );
 
-  server.registerTool(
-    "setCoursePublic",
+  registerApprovedTool(
+    server,
     {
+      name: "setCoursePublic",
       description:
         "Turn public access to a course on or off. Public means anyone holding the link — or visiting a page carrying the embed — can open the course without signing in or being enrolled. " +
-        "This is what makes a getCourseEmbed snippet actually render, so it is the last step of publishing a course to the outside world. " +
-        "The calling client asks the author to approve before anything changes; never ask for that approval in plain text. " +
-        "A declined call comes back as success:false with nothing changed — an answer, not a failure, so do not call again.",
+        "This is what makes a getCourseEmbed snippet actually render, so it is the last step of publishing a course to the outside world.",
       inputSchema: z.object({
         courseId: courseIdSchema,
         isPublic: z
@@ -136,8 +126,9 @@ export function registerPublishingTools(server: McpServer, userId: string) {
           ),
       }),
       annotations: { idempotentHint: true },
+      undone: "nothing changed",
     },
-    async ({ courseId, isPublic }, ctx) => {
+    async ({ courseId, isPublic }) => {
       const course = await readable("setCoursePublic", () =>
         getCourse(userId, courseId),
       );
@@ -151,19 +142,19 @@ export function registerPublishingTools(server: McpServer, userId: string) {
         });
       }
 
-      const gate = approval(ctx, {
-        token: approvalToken("setCoursePublic", courseId, [String(isPublic)]),
-        refusals: REFUSALS,
+      return {
+        courseId,
+        ids: [String(isPublic)],
         message: isPublic
           ? `Make "${course.title}" public? Anyone with the link, and anyone visiting a page that embeds it, will be able to open the course without signing in or enrolling. This can be turned off again.`
           : `Make "${course.title}" private again? The public link will stop working, and any page already embedding this course will show "not publicly accessible" instead.`,
-      });
-      if (gate) return gate;
-
-      await readable("setCoursePublic", () =>
-        updateCourse(userId, { courseId, allowAnonymous: isPublic }),
-      );
-      return text({ success: true, courseId, isPublic });
+        run: async () => {
+          await readable("setCoursePublic", () =>
+            updateCourse(userId, { courseId, allowAnonymous: isPublic }),
+          );
+          return { success: true, courseId, isPublic };
+        },
+      };
     },
   );
 }

--- a/docs/adr/0006-deletion-approval-is-asked-of-the-client.md
+++ b/docs/adr/0006-deletion-approval-is-asked-of-the-client.md
@@ -1,34 +1,63 @@
 # Deletion approval is asked of the client, not enforced by Scibly
 
-External agents may delete draft scenes and lessons, and the author's approval
-is collected as an MCP elicitation the calling client renders — not as a pending
-deletion the author confirms inside Scibly. We chose the client-side gate
-because the failure being guarded against is the model getting it wrong rather
-than a hostile client: a client willing to forge an approval can equally skip
-asking for one, so enforcing it on our side buys no real protection while
-costing a pending-deletion store, an inbox to work it, and a delete tool that
-answers "ask your author" instead of a result. Courses are deliberately
-excluded — deleting one cascades through published versions and enrollments,
-and an unenforceable gate is not what should stand in front of that.
+External agents may delete draft scenes and lessons. The author's approval is
+collected as an MCP elicitation that the calling client renders, not as a
+pending deletion the author confirms inside Scibly. We chose the client-side
+gate because what we are guarding against is the model getting it wrong, not a
+hostile client. A client willing to forge an approval can equally skip asking
+for one, so enforcing it on our side buys no real protection while costing a
+pending-deletion store, an inbox to work it, and a delete tool that answers
+"ask your author" instead of a result. Courses are deliberately excluded.
+Deleting one cascades through published versions and enrollments, and an
+unenforceable gate has no business standing in front of that.
 
 ## Consequences
 
 - The approval is a user-interaction model, not a boundary. Anything that must
   actually be prevented has to be refused server-side, on its own merits.
 - The approval binds to a specific deletion through the ids the server mints
-  into `requestState` and compares on retry, so a model that re-plans between
+  into `requestState` and compares on retry. A model that re-plans between
   asking and being answered is refused rather than deleting a set nobody saw.
-  The state is unsigned on purpose: signing only raises the cost of an attack
+  The state is unsigned on purpose. Signing only raises the cost of an attack
   this gate already concedes.
-- Clients that cannot elicit are refused, not served an ungated delete.
+- Clients that cannot elicit confirm over two calls instead. The amendment
+  below covers that path. Neither path is ever an ungated delete.
 
 ## Not claimed: single use
 
 The approval state carries no nonce and no expiry. A delete can return without
-deleting — a last scene, a published scene, a serialization conflict — and the
-same state still opens the gate afterwards, so an agent may retry within the
-session without asking again. That is accepted: the author approved this exact
-item set, for this tool, in this course, and the window is one MCP session.
+deleting: a last scene, a published scene, a serialization conflict. The same
+state still opens the gate afterwards, so an agent may retry within the session
+without asking again. That is accepted. The author approved this exact item
+set, for this tool, in this course, and the window is one MCP session.
 
-The SDK's `createRequestStateCodec` TTL is the seam if that ever stops being
-true. Recorded here so it is not re-found as a defect.
+The SDK's `createRequestStateCodec` TTL is where an expiry would go if that
+ever stops being true. Written down so nobody re-files it as a bug.
+
+## Amendment: clients that cannot elicit confirm over two calls
+
+Originally these tools refused any client that could not be elicited. That
+refused every client there is. We serve `legacy: 'stateless'` alongside the
+2026-07-28 path, and a 2025-era request is a single exchange with no session,
+so `elicitation/create` cannot be sent on it at all. The capability envelope
+never arrives either. Claude, ChatGPT and everything else land there, and all
+four gated tools were dead on arrival.
+
+Such a client now confirms over two calls. The first returns
+`success: false, needsConfirmation: true` with the same summary the dialog
+would have shown, plus the `confirmationToken` that opens it. The caller puts
+that summary in front of the author and calls again with the token. The token
+is the same `approvalToken` value, so the binding is unchanged: it pins the
+tool, the course and the sorted id set, and a token minted for a different set
+is refused. Elicitation stays preferred wherever the capability is present.
+
+This concedes nothing the ADR had not already conceded. A model can pass a
+token it never showed anyone, but a model can equally skip asking before
+elicitation. The gate was never a boundary, and a fabricated token still
+requires having enumerated the exact ids it is about to delete. What the author
+actually sees is the client's own destructive-tool approval on the second call,
+which `destructiveHint: true` already asks for.
+
+The gate becomes a boundary only if we drop the two-call path for a sessionful
+2025 transport, or once clients speak 2026-07-28. Neither is worth doing for
+this.


### PR DESCRIPTION
## What & why

<!-- What does this change, and why? Link an issue if there is one. -->

## Checklist

- [x] `pnpm check` passes (typecheck + lint + format)
- [x] `pnpm test:unit` passes
- [x] For `apps/app`/`apps/web` changes, ran `pnpm --filter <@scibly/app|@scibly/web> run format:check`
