### PR TITLE
Keep every agent SKILL and contract in notebook-skills/

### DIFF
--- a/apps/app/notebook-skills/authoring-rules.md
+++ b/apps/app/notebook-skills/authoring-rules.md
@@ -1,0 +1,13 @@
+### Non-negotiable authoring rules (always active while a course is in focus)
+
+- You are a trainer, not a lecturer: scenes test and guide, they never lecture. Turn explanations into tasks or one-sentence guide beats.
+- A scene is ONE task, not a page: one interaction, one guide-character beat, or one media nugget. Setup text is at most 1-2 short sentences.
+- No headings (h1-h6) inside scene content. The scene IS the task; framing comes from the guide character or a short plain sentence.
+- Scenes build on each other and are not individually self-contained. The lesson is the smallest repeatable learning unit. Never re-explain context from a previous scene.
+- Prefer active production (learner assembles or types the answer: cloze word bank, drag-and-drop, input) over recognition-only multiple choice.
+- Explanations and feedback speak through the course's guide character, not as anonymous exposition. Never a scene with only plain text.
+- Questions test decisions, never recall of a number/date from a source. Figures belong in the scenario setup, not in the answer.
+- Each distractor represents a real, nameable misconception.
+- Vary block types across a lesson; multiple choice at most once unless asked. Vary cognitive levels (Remember early, Apply/Analyze later).
+- No em/en dashes in learner-facing copy.
+- Fix any `qualityWarning` from insertContent immediately before writing the next scene.

--- a/apps/app/notebook-skills/practice-contract.md
+++ b/apps/app/notebook-skills/practice-contract.md
@@ -1,29 +1,8 @@
-export const PRACTICE_CONTRACT = `# Practice scene contract
+# Practice scene contract
 
-## What a practice scene is
-
-A small app the learner *operates*, not a question they answer. They drag,
-aim, build, connect, step, toggle or run something; the app reacts visibly
-on every interaction; and the submitted work is the state their play
-arrived at.
-
-These are rejected however good the prose around them is:
-
-- question text followed by <input> fields and a Submit button
-- a "simulation" whose only interactive parts are numeric fields
-- anything a learner could answer identically with the app deleted
-
-If it can be solved on paper and then typed in, it is a DOCUMENT scene with
-a question block. Do not build it here.
-
-So: draw the state (canvas, SVG or live DOM) and redraw on every change.
-Let the learner act on that drawing directly, and answer immediately —
-motion, a highlight, a counter, a trace that builds up. Setup controls
-(sliders, presets, a Run button) are fine when the run is the point; a panel
-of number fields with nothing to watch is the anti-pattern above. For a
-physics scene that means a body actually moving under the parameters the
-learner set, and submit(work) reporting the configuration they *found* —
-not the number they computed in their head.
+What the platform injects, enforces and refuses. This is the mechanical half:
+it tells you what your code must call, not what makes a practice scene worth
+building — load the `practice-scenes` skill for that.
 
 ## The fragment
 
@@ -34,16 +13,9 @@ session). Inline <style>/<script> are fine. Do not include <!DOCTYPE>,
 <html>, or <head> — those are added automatically at render time, along
 with a CSP, Scibly's design tokens, and the SDK below.
 
-The page ground is transparent and the frame is seamless: your fragment IS
-the scene the learner is looking at, not a widget embedded in one. Do not
-paint a full-bleed page background or wrap everything in one big card —
-colour only the surfaces that mean something (a stage, a panel, a token).
-
-You get the whole scene column, up to ~1150px wide, and the frame grows to
-whatever height your body needs. Lay the app out edge to edge and use the
-space: a stage/canvas that fills the width with controls beside or below it,
-not a 600px column centred in the middle. Do not cap your own width, and stay
-responsive down to ~360px — the same fragment renders on phones.
+The page ground is transparent and the frame is seamless. You get the whole
+scene column, up to ~1150px wide, the frame grows to whatever height your body
+needs, and the same fragment renders on phones down to ~360px.
 
 ## SDK (window.scibly)
 
@@ -63,15 +35,11 @@ submit is graded immediately, server-side, against the stored solution, and
 is the single scored event for the scene. Retrying inside the app before
 submit is free and ungraded.
 
-## Exploratory scenes (no submit, no Submit button)
+## Scenes with no solution
 
-Not every practice has a right answer. When the point is for the learner to
-play with something until its behaviour clicks — a sandbox, a what-if,
-a thing to take apart — pass solution: null, never call submit, and build no
-Submit button at all. The player awards the scene's SP when the learner
-presses Next, and shows your "explanation" under the app as the takeaway
-before they move on. Write one: it is the only thing the platform says about
-an exploratory scene.
+Pass solution: null, never call submit, and build no Submit button at all. The
+player awards the scene's SP when the learner presses Next, and shows your
+"explanation" under the app as the takeaway before they move on.
 
 Everything below — onGraded, the field-by-field solution, the self-test —
 applies only when the scene has a solution. Skip all three if it does not.
@@ -88,15 +56,8 @@ running app:
 
 Register it once at startup. It fires after submit (and immediately at boot
 in "review" mode, where the same grade also sits in previous.grade), so
-write one render path that handles both.
-
-An app that prints "Submitted." and goes inert is a dead end — the learner
-never finds out which of their eight decisions was wrong, which is the whole
-point of the exercise. When the grade arrives, mark up *the things the
-learner touched*: turn each misjudged email red in the list, snap the wrong
-connection back, replay the trajectory that missed. grade.fields[id].expected
-carries the right answer, so show it next to what they chose. Keep the app on
-screen and readable — do not clear it, do not blank the stage.
+write one render path that handles both. grade.fields[id].expected carries the
+right answer.
 
 ## Solution schema (writePractice's "solution" argument)
 
@@ -151,13 +112,13 @@ Ordering by direct manipulation — click one step, click another, they swap:
     let picked = null;
 
     function render() {
-      document.getElementById("app").innerHTML = \`
+      document.getElementById("app").innerHTML = `
         <p>Put the steps in the order they run.</p>
-        \${order.map((step, slot) => \`
-          <button data-slot="\${slot}" style="display:block;width:100%;margin:4px 0;
-            border:2px solid \${picked === slot ? "#0066FF" : "#eceae4"};border-radius:12px;
-            padding:10px;background:#fff;cursor:pointer">\${STEPS[step]}</button>\`).join("")}
-        <button id="go">Submit</button>\`;
+        ${order.map((step, slot) => `
+          <button data-slot="${slot}" style="display:block;width:100%;margin:4px 0;
+            border:2px solid ${picked === slot ? "#0066FF" : "#eceae4"};border-radius:12px;
+            padding:10px;background:#fff;cursor:pointer">${STEPS[step]}</button>`).join("")}
+        <button id="go">Submit</button>`;
 
       document.querySelectorAll("[data-slot]").forEach((el) => {
         el.onclick = () => {
@@ -184,7 +145,7 @@ Ordering by direct manipulation — click one step, click another, they swap:
         el.style.borderColor = ok ? "#58cc02" : "#e5484d";
       });
       document.getElementById("go").outerHTML = field.correct
-        ? "<p>Correct \u2014 " + grade.sp + " SP.</p>"
+        ? "<p>Correct — " + grade.sp + " SP.</p>"
         : "<p>Right order: " + field.expected + "</p>";
     });
 
@@ -197,4 +158,3 @@ writePractice's solution argument for this app:
 
 Note the order is submitted as a joined string: array values are compared as
 sets, so an array would grade a shuffled answer as correct.
-`;

--- a/apps/app/notebook-skills/practice-scenes/SKILL.md
+++ b/apps/app/notebook-skills/practice-scenes/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: practice-scenes
+description: How to design a PRACTICE scene worth building — a small app the learner operates (drags, aims, builds, runs) rather than a question they answer. Covers what gets rejected, drawing a state the learner acts on, laying the app out in the scene column, when a scene should be exploratory instead of graded, and how to show the grade so the learner learns from it. Load before writing or editing a PRACTICE scene with writePractice or validatePractice. A question with input fields and a Submit button is not a practice scene — that is a DOCUMENT scene question block, so load scene-content instead.
+---
+
+# Designing a practice scene
+
+This is the design half. It says nothing about the SDK, the solution schema,
+the self-test hook or what publishing refuses — call `getPracticeContract` for
+those, and call it before you write any code. You cannot build a scene from
+this file alone.
+
+## What a practice scene is
+
+A small app the learner *operates*, not a question they answer. They drag,
+aim, build, connect, step, toggle or run something; the app reacts visibly
+on every interaction; and the submitted work is the state their play
+arrived at.
+
+These are rejected however good the prose around them is:
+
+- question text followed by <input> fields and a Submit button
+- a "simulation" whose only interactive parts are numeric fields
+- anything a learner could answer identically with the app deleted
+
+If it can be solved on paper and then typed in, it is a DOCUMENT scene with
+a question block. Do not build it here.
+
+So: draw the state (canvas, SVG or live DOM) and redraw on every change.
+Let the learner act on that drawing directly, and answer immediately —
+motion, a highlight, a counter, a trace that builds up. Setup controls
+(sliders, presets, a Run button) are fine when the run is the point; a panel
+of number fields with nothing to watch is the anti-pattern above. For a
+physics scene that means a body actually moving under the parameters the
+learner set, and submit(work) reporting the configuration they *found* —
+not the number they computed in their head.
+
+## Filling the scene
+
+Your fragment IS the scene the learner is looking at, not a widget embedded in
+one — the ground is transparent and the frame seamless. Do not paint a
+full-bleed page background or wrap everything in one big card: colour only the
+surfaces that mean something (a stage, a panel, a token).
+
+Use the space you are given. Lay the app out edge to edge — a stage or canvas
+that fills the width with controls beside or below it, not a 600px column
+centred in the middle. Do not cap your own width, and stay responsive down to
+phone widths, because the same fragment renders there.
+
+## When a scene should be exploratory
+
+Not every practice has a right answer. When the point is for the learner to
+play with something until its behaviour clicks — a sandbox, a what-if, a thing
+to take apart — make it exploratory: no solution, no submit, no Submit button.
+
+Write the "explanation" carefully when you do. It is the only thing the
+platform says about an exploratory scene, and the learner reads it as the
+takeaway before they move on.
+
+## Making the grade teach
+
+An app that prints "Submitted." and goes inert is a dead end — the learner
+never finds out which of their eight decisions was wrong, which is the whole
+point of the exercise.
+
+When the grade arrives, mark up *the things the learner touched*: turn each
+misjudged email red in the list, snap the wrong connection back, replay the
+trajectory that missed. Show the right answer next to what they chose. Keep
+the app on screen and readable — do not clear it, do not blank the stage.

--- a/apps/app/notebook-skills/system-prompt.md
+++ b/apps/app/notebook-skills/system-prompt.md
@@ -1,0 +1,28 @@
+# Scibly Course Creation Expert
+
+You are Scibly's AI Learning Designer.
+
+Your goal is to help subject matter experts (SMEs) transform their knowledge into highly engaging, interactive micro-learning experiences, even if they have no background in instructional design.
+
+You are not a content summarizer. You are an expert instructional designer, microlearning specialist, assessment designer, and learning coach.
+
+## Core mission
+
+Help users create courses that are short, focused, practical, interactive, and designed around measurable learning outcomes. Prioritize learning effectiveness over content completeness. The goal is not to teach everything—it is to teach what matters so learners can perform, decide correctly, and apply knowledge in practice.
+
+## How you work
+
+1. **Skills first** — Load the relevant skill with `loadSkill` before detailed design, authoring, source work, or invalidation. Do not guess at domain rules.
+2. **Tools** — Consult the source material (see that section for how to reach it), read and write scenes, manage courses, browse the notebook media library with `listNotebookMedia` (reuse existing images before generating new ones), generate images with `generateImage` (always include `alt`), and collect structured input with `askMultipleChoice` (clickable options or batch wizard) and `proposePlan` (confirmable step-by-step plans). Follow the loaded skill's workflow. When the user sends localized image comments (numbered positions with instructions), call `generateImage` with `sourceImageId` set to the referenced image and `regions` built from those comments — copy each position's x/y and text exactly so the model refines only the marked spots and leaves the rest of the image unchanged.
+3. **Coach proactively** — Tighten weak content, push back on overload, and turn explanations into activities and scenarios.
+4. **Voice** — Direct, encouraging, and practical. You are a design partner, not a lecturer.
+5. **Close every turn visibly** — After your last tool call finishes (including approval-gated tools, content writes, plan confirmations, or multiple-choice answers), write a brief final message summarizing the outcome. Then stop — do not call more tools until the user sends a new message. Never end a turn with only internal reasoning/thinking — the chat must always show a clear closing reply the user can read without opening "Thinking".
+6. **Never think out loud** — Everything you write between tool calls is shown to the user as your reply. Weighing options, second-guessing yourself, restating what a tool returned, or narrating your next move ("Hmm, but…", "Let me check…", "Good.") belongs in your reasoning, never in that text. If a step needs any visible text at all, make it one short sentence telling the user what you are doing and why it helps them. Otherwise write nothing and call the next tool.
+
+## Approval-gated tools
+
+Some tools require explicit user approval via an inline confirmation card in chat. Do not duplicate that confirmation in plain text — call the tool and let the UI handle it.
+
+When the user approves and the tool finishes, read the tool result and reply with a brief summary. Stop there unless the user sends a new message asking for more.
+
+When users provide raw documents, notes, or expertise, help transform them into effective learning experiences.

--- a/apps/app/src/app/api/chat/generation-debit.integration.test.ts
+++ b/apps/app/src/app/api/chat/generation-debit.integration.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 // Proves two requests racing one credit actually serialize in Postgres, which no mocked
 // client can witness; opt in by setting this to a disposable database (setup: docs/integration-tests.md).
-const url = process.env.ENTITLEMENT_INT_TEST_DATABASE_URL ?? "";
+const url = process.env.INT_TEST_DATABASE_URL ?? "";
 
 const RUN_ID = `int-entitlement-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 const ORG = `${RUN_ID}-org`;

--- a/apps/app/src/features/course-authoring/tools/practice-tools.test.ts
+++ b/apps/app/src/features/course-authoring/tools/practice-tools.test.ts
@@ -1,0 +1,23 @@
+import type { NotebookRuntimeContext } from "@/features/notebook/server";
+
+import { describe, expect, it } from "vitest";
+
+import { buildPracticeTools } from "./practice-tools";
+
+describe("the practice contract the agent is handed", () => {
+  it("comes back frontmatter-free, carrying the SDK, the self-test hook and the CDN", async () => {
+    // execute() reads a file and never touches the caller.
+    const tools = buildPracticeTools({} as NotebookRuntimeContext);
+
+    const result = await tools.getPracticeContract.execute!(
+      {},
+      { toolCallId: "t1", messages: [], context: {} },
+    );
+    if (!("contract" in result)) throw new Error("expected a contract");
+
+    expect(result.contract.startsWith("# Practice scene contract")).toBe(true);
+    expect(result.contract).toContain("window.scibly.submit(work)");
+    expect(result.contract).toContain("window.__sciblySelfTest");
+    expect(result.contract).toContain("cdnjs.cloudflare.com");
+  });
+});

--- a/apps/app/src/features/course-authoring/tools/practice-tools.ts
+++ b/apps/app/src/features/course-authoring/tools/practice-tools.ts
@@ -3,7 +3,7 @@ import type { NotebookRuntimeContext } from "@/features/notebook/server";
 import { tool } from "ai";
 import { z } from "zod";
 
-import { PRACTICE_CONTRACT } from "@/shared/content/practice/practice-contract";
+import { readAgentProse } from "@/shared/ai/agent-prose";
 
 import {
   getPracticeSchema,
@@ -19,7 +19,9 @@ export function buildPracticeTools(context: NotebookRuntimeContext) {
         "the self-test hook, when a scene needs no submit at all, the CDN allowlist and a worked example. " +
         "You MUST call this BEFORE using writePractice to know the SDK your app must call.",
       inputSchema: z.object({}),
-      execute: async () => ({ contract: PRACTICE_CONTRACT }),
+      execute: async () => ({
+        contract: await readAgentProse("practice-contract.md"),
+      }),
     }),
     getPractice: tool({
       description:

--- a/apps/app/src/features/mcp/server/create-course.integration.test.ts
+++ b/apps/app/src/features/mcp/server/create-course.integration.test.ts
@@ -4,8 +4,8 @@ import type * as DbModule from "@scibly/db";
 import { createTestPrismaClient } from "@scibly/db/test-client";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-// Opt in via MCP_INT_TEST_DATABASE_URL (docs/integration-tests.md).
-const url = vi.hoisted(() => process.env.MCP_INT_TEST_DATABASE_URL ?? "");
+// Opt in via INT_TEST_DATABASE_URL (docs/integration-tests.md).
+const url = vi.hoisted(() => process.env.INT_TEST_DATABASE_URL ?? "");
 
 vi.mock("@scibly/db", async (importOriginal) => ({
   ...(await importOriginal<typeof DbModule>()),

--- a/apps/app/src/features/mcp/server/handler.test.ts
+++ b/apps/app/src/features/mcp/server/handler.test.ts
@@ -499,6 +499,48 @@ describe("calling a tool over MCP", () => {
     });
   });
 
+  it("MCP1: keeps an internal failure inside the server", async () => {
+    const { caller, list } = fakeCaller();
+    list.mockRejectedValue(
+      new Error("ENOENT: /var/task/apps/app/notebook-skills/system-prompt.md"),
+    );
+
+    const { body } = await post(
+      rpc("tools/call", {
+        name: "listCourses",
+        arguments: { orgSlug: "acme" },
+      }),
+      caller,
+    );
+
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0].text).toBe(
+      "Scibly could not be reached. Try again.",
+    );
+  });
+
+  it("MCP1: still hands over a refusal the agent can act on", async () => {
+    const { caller, list } = fakeCaller();
+    list.mockRejectedValue(
+      new AppError({
+        code: "FORBIDDEN",
+        applicationCode: "api.forbidden",
+        message: "You are not a member of acme.",
+      }),
+    );
+
+    const { body } = await post(
+      rpc("tools/call", {
+        name: "listCourses",
+        arguments: { orgSlug: "acme" },
+      }),
+      caller,
+    );
+
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0].text).toContain("not a member of acme");
+  });
+
   it("MCP1: does not expose a tool that was left off the surface", async () => {
     const { body } = await post(
       rpc("tools/call", {

--- a/apps/app/src/features/mcp/server/handler.ts
+++ b/apps/app/src/features/mcp/server/handler.ts
@@ -14,7 +14,7 @@ import { registerCourseTools } from "./course-tools";
 import { registerDeletionTools } from "./deletion-tools";
 import { registerPublishingTools } from "./publishing-tools";
 import { registerSceneContentTools } from "./scene-content-tools";
-import { text } from "./tool-response";
+import { readable, text } from "./tool-response";
 import { MCP_TOOL_NAMES, mcpToolInput } from "./tool-surface";
 
 /** MCP has no transcript, so a tool that actually streams needs a real writer before it is allow-listed. */
@@ -76,14 +76,16 @@ export async function handleMcpRequest(
           typeof tool.description === "string" ? tool.description : undefined,
         inputSchema: mcpToolInput(name, tool.inputSchema),
       },
-      async (args) => {
-        const output = await execute(args, {
-          toolCallId: name,
-          messages: [],
-          context: undefined,
-        });
-        return text(output);
-      },
+      async (args) =>
+        text(
+          await readable(name, () =>
+            execute(args, {
+              toolCallId: name,
+              messages: [],
+              context: undefined,
+            }),
+          ),
+        ),
     );
   }
 

--- a/apps/app/src/features/mcp/server/practice-scenes.integration.test.ts
+++ b/apps/app/src/features/mcp/server/practice-scenes.integration.test.ts
@@ -10,8 +10,8 @@ import type * as NextServer from "next/server";
 import { createTestPrismaClient } from "@scibly/db/test-client";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-// Opt in via MCP_INT_TEST_DATABASE_URL (docs/integration-tests.md).
-const url = vi.hoisted(() => process.env.MCP_INT_TEST_DATABASE_URL ?? "");
+// Opt in via INT_TEST_DATABASE_URL (docs/integration-tests.md).
+const url = vi.hoisted(() => process.env.INT_TEST_DATABASE_URL ?? "");
 
 vi.mock("@scibly/db", async (importOriginal) => ({
   ...(await importOriginal<typeof DbModule>()),

--- a/apps/app/src/features/notebook/chat/server/prompt.ts
+++ b/apps/app/src/features/notebook/chat/server/prompt.ts
@@ -1,36 +1,11 @@
-import { APPROVAL_GATED_TOOLS_SYSTEM_PROMPT } from "@/features/notebook/chat/tools/approval-tools";
 import { quoteSourceName } from "@/features/notebook/sources/server/source-passage";
-
-export const CORE_SYSTEM_PROMPT = `# Scibly Course Creation Expert
-
-You are Scibly's AI Learning Designer.
-
-Your goal is to help subject matter experts (SMEs) transform their knowledge into highly engaging, interactive micro-learning experiences, even if they have no background in instructional design.
-
-You are not a content summarizer. You are an expert instructional designer, microlearning specialist, assessment designer, and learning coach.
-
-## Core mission
-
-Help users create courses that are short, focused, practical, interactive, and designed around measurable learning outcomes. Prioritize learning effectiveness over content completeness. The goal is not to teach everything—it is to teach what matters so learners can perform, decide correctly, and apply knowledge in practice.
-
-## How you work
-
-1. **Skills first** — Load the relevant skill with \`loadSkill\` before detailed design, authoring, source work, or invalidation. Do not guess at domain rules.
-2. **Tools** — Consult the source material (see that section for how to reach it), read and write scenes, manage courses, browse the notebook media library with \`listNotebookMedia\` (reuse existing images before generating new ones), generate images with \`generateImage\` (always include \`alt\`), and collect structured input with \`askMultipleChoice\` (clickable options or batch wizard) and \`proposePlan\` (confirmable step-by-step plans). Follow the loaded skill's workflow. When the user sends localized image comments (numbered positions with instructions), call \`generateImage\` with \`sourceImageId\` set to the referenced image and \`regions\` built from those comments — copy each position's x/y and text exactly so the model refines only the marked spots and leaves the rest of the image unchanged.
-3. **Coach proactively** — Tighten weak content, push back on overload, and turn explanations into activities and scenarios.
-4. **Voice** — Direct, encouraging, and practical. You are a design partner, not a lecturer.
-5. **Close every turn visibly** — After your last tool call finishes (including approval-gated tools, content writes, plan confirmations, or multiple-choice answers), write a brief final message summarizing the outcome. Then stop — do not call more tools until the user sends a new message. Never end a turn with only internal reasoning/thinking — the chat must always show a clear closing reply the user can read without opening "Thinking".
-6. **Never think out loud** — Everything you write between tool calls is shown to the user as your reply. Weighing options, second-guessing yourself, restating what a tool returned, or narrating your next move ("Hmm, but…", "Let me check…", "Good.") belongs in your reasoning, never in that text. If a step needs any visible text at all, make it one short sentence telling the user what you are doing and why it helps them. Otherwise write nothing and call the next tool.
-
-${APPROVAL_GATED_TOOLS_SYSTEM_PROMPT}
-
-When users provide raw documents, notes, or expertise, help transform them into effective learning experiences.`;
 
 interface UiContext {
   orgSlug: string;
   course?: { id: string; title: string };
   lesson?: { id: string; title: string };
   scene?: { id: string; title: string };
+  authoringRules: string;
 }
 
 export function uiContextSection({
@@ -38,6 +13,7 @@ export function uiContextSection({
   course,
   lesson,
   scene,
+  authoringRules,
 }: UiContext): string {
   const lines = ["## Current focus", "", `- Organization: \`${orgSlug}\``];
 
@@ -58,19 +34,7 @@ export function uiContextSection({
       "",
       "Use these IDs for tool calls tied to the user's workspace. Load `scene-content` when creating or editing scene content.",
       "",
-      "### Non-negotiable authoring rules (always active while a course is in focus)",
-      "",
-      "- You are a trainer, not a lecturer: scenes test and guide, they never lecture. Turn explanations into tasks or one-sentence guide beats.",
-      "- A scene is ONE task, not a page: one interaction, one guide-character beat, or one media nugget. Setup text is at most 1-2 short sentences.",
-      "- No headings (h1-h6) inside scene content. The scene IS the task; framing comes from the guide character or a short plain sentence.",
-      "- Scenes build on each other and are not individually self-contained. The lesson is the smallest repeatable learning unit. Never re-explain context from a previous scene.",
-      "- Prefer active production (learner assembles or types the answer: cloze word bank, drag-and-drop, input) over recognition-only multiple choice.",
-      "- Explanations and feedback speak through the course's guide character, not as anonymous exposition. Never a scene with only plain text.",
-      "- Questions test decisions, never recall of a number/date from a source. Figures belong in the scenario setup, not in the answer.",
-      "- Each distractor represents a real, nameable misconception.",
-      "- Vary block types across a lesson; multiple choice at most once unless asked. Vary cognitive levels (Remember early, Apply/Analyze later).",
-      "- No em/en dashes in learner-facing copy.",
-      "- Fix any `qualityWarning` from insertContent immediately before writing the next scene.",
+      authoringRules,
     );
   } else {
     lines.push(

--- a/apps/app/src/features/notebook/chat/server/utils/context.test.ts
+++ b/apps/app/src/features/notebook/chat/server/utils/context.test.ts
@@ -1,14 +1,19 @@
+import type * as SkillsModule from "../../../skills";
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// Only the database and the skill catalogue are doubled — the tier decision,
-// the budget arithmetic, and the serialization all run for real.
+// Only the database and the skill *listing* are doubled — the prompt files in
+// notebook-skills/ are read for real, so the snapshots below cover them too.
 const db = vi.hoisted(() => ({
   notebookSource: { findMany: vi.fn() },
   scene: { findMany: vi.fn() },
 }));
 
 vi.mock("@scibly/db", () => ({ db }));
-vi.mock("../../../skills", () => ({ buildSkillsPrompt: () => "" }));
+vi.mock("../../../skills", async (importOriginal) => ({
+  ...(await importOriginal<typeof SkillsModule>()),
+  buildSkillsPrompt: () => "",
+}));
 
 const { buildSystemPrompt } = await import("./context");
 

--- a/apps/app/src/features/notebook/chat/server/utils/context.ts
+++ b/apps/app/src/features/notebook/chat/server/utils/context.ts
@@ -4,6 +4,7 @@ import {
   quoteSourceName,
   toSourcePassage,
 } from "@/features/notebook/sources/server/source-passage";
+import { readAgentProse } from "@/shared/ai/agent-prose";
 import { estimateTokens } from "@/shared/ai/token-estimate";
 import { outdatedDraftSceneWhere } from "@/shared/content/course/course-outdated";
 import {
@@ -12,7 +13,7 @@ import {
 } from "@/shared/content/sources/constants";
 
 import { buildSkillsPrompt, type SkillMetadata } from "../../../skills";
-import { CORE_SYSTEM_PROMPT, uiContextSection } from "../prompt";
+import { uiContextSection } from "../prompt";
 import { type StreamChatInput } from "./schema";
 
 const FRESHNESS_QUERY =
@@ -245,15 +246,18 @@ export async function buildSystemPrompt(
   }: ChatContextOptions,
   skills: SkillMetadata[],
 ): Promise<{ prompt: string; tier: SourceContextTier }> {
-  const [sources, outdatedScenesContext] = await Promise.all([
-    buildSourceContext({ notebookId, contextWindow }),
-    buildOutdatedScenesContext(courseContext?.course.id, query),
-  ]);
+  const [core, authoringRules, sources, outdatedScenesContext] =
+    await Promise.all([
+      readAgentProse("system-prompt.md"),
+      readAgentProse("authoring-rules.md"),
+      buildSourceContext({ notebookId, contextWindow }),
+      buildOutdatedScenesContext(courseContext?.course.id, query),
+    ]);
 
   const skillsPrompt = buildSkillsPrompt(skills);
 
   const prompt = [
-    CORE_SYSTEM_PROMPT,
+    core,
     skillsPrompt,
 
     sources.block,
@@ -262,6 +266,7 @@ export async function buildSystemPrompt(
       course: courseContext?.course,
       lesson: courseContext?.lesson,
       scene: courseContext?.scene,
+      authoringRules,
     }),
     outdatedScenesContext,
   ]

--- a/apps/app/src/features/notebook/chat/tools/approval-tools.ts
+++ b/apps/app/src/features/notebook/chat/tools/approval-tools.ts
@@ -9,12 +9,6 @@ import {
 
 import { isApprovalGatedTool } from "./client-tool-definitions";
 
-export const APPROVAL_GATED_TOOLS_SYSTEM_PROMPT = `## Approval-gated tools
-
-Some tools require explicit user approval via an inline confirmation card in chat. Do not duplicate that confirmation in plain text — call the tool and let the UI handle it.
-
-When the user approves and the tool finishes, read the tool result and reply with a brief summary. Stop there unless the user sends a new message asking for more.`;
-
 function isApprovalGatedPart(
   part: UIMessage["parts"][number],
 ): part is ToolUIPart | DynamicToolUIPart {

--- a/apps/app/src/features/notebook/skills/catalogue.ts
+++ b/apps/app/src/features/notebook/skills/catalogue.ts
@@ -1,27 +1,21 @@
 import type { SkillMetadata } from "./types";
 
-import path from "node:path";
-
 import "server-only";
+import { env } from "@/env";
+import { agentFilesRoot } from "@/shared/ai/agent-prose";
 
 import { discoverSkills } from "./discover";
 import { nodeSandbox } from "./sandbox";
 
-let cachedSkills: SkillMetadata[] | null = null;
+// discoverSkills swallows every filesystem error it meets, so this can never cache a rejection.
+let cachedSkills: Promise<SkillMetadata[]> | null = null;
 
-export async function getNotebookSkills(): Promise<SkillMetadata[]> {
-  if (process.env.NODE_ENV === "production" && cachedSkills) {
-    return cachedSkills;
-  }
+export function getNotebookSkills(): Promise<SkillMetadata[]> {
+  const walk = () => discoverSkills(nodeSandbox, [agentFilesRoot()]);
 
-  const root = path.join(process.cwd(), "notebook-skills");
-  const skills = await discoverSkills(nodeSandbox, [root]);
+  if (env.NODE_ENV !== "production") return walk();
 
-  if (process.env.NODE_ENV === "production") {
-    cachedSkills = skills;
-  }
-
-  return skills;
+  return (cachedSkills ??= walk());
 }
 
 export function clearNotebookSkillsCache(): void {

--- a/apps/app/src/features/notebook/skills/notebook-skills-on-disk.test.ts
+++ b/apps/app/src/features/notebook/skills/notebook-skills-on-disk.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { getNotebookSkills } from "./catalogue";
+
+// Vitest's cwd is apps/app, so agentFilesRoot() resolves to the folder we deploy.
+describe("the skills the app ships", () => {
+  it("discovers every skill folder, and nothing beside them", async () => {
+    const names = (await getNotebookSkills()).map((skill) => skill.name).sort();
+
+    expect(names).toEqual([
+      "batch-flow",
+      "discovery",
+      "educational-visuals",
+      "lesson-design",
+      "practice-scenes",
+      "review-check",
+      "scene-content",
+    ]);
+  });
+});

--- a/apps/app/src/features/notebook/sources/server/search-sources.integration.test.ts
+++ b/apps/app/src/features/notebook/sources/server/search-sources.integration.test.ts
@@ -1,9 +1,9 @@
 import { createTestPrismaClient } from "@scibly/db/test-client";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-// Opt-in: set SOURCES_INT_TEST_DATABASE_URL to a disposable database (see
+// Opt-in: set INT_TEST_DATABASE_URL to a disposable database (see
 // docs/integration-tests.md); skipped when unset.
-const url = vi.hoisted(() => process.env.SOURCES_INT_TEST_DATABASE_URL ?? "");
+const url = vi.hoisted(() => process.env.INT_TEST_DATABASE_URL ?? "");
 
 // The functions under test read the app's singleton client, which is pinned to
 // a fake URL in the test setup — point it at the disposable database instead.

--- a/apps/app/src/features/organizations/server/plan-upgrade.integration.test.ts
+++ b/apps/app/src/features/organizations/server/plan-upgrade.integration.test.ts
@@ -4,8 +4,8 @@ import { PLAN_CATALOGUE } from "@scibly/ee-billing/plan-catalogue";
 import { syncSubscription } from "@scibly/ee-billing/sync-subscription";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-// Runs against a real Postgres increment, unlike PC2/PC3's mocked client — no mock can prove a charge survives a concurrent upgrade webhook. Opt in via ENTITLEMENT_INT_TEST_DATABASE_URL (docs/integration-tests.md).
-const url = process.env.ENTITLEMENT_INT_TEST_DATABASE_URL ?? "";
+// Runs against a real Postgres increment, unlike PC2/PC3's mocked client — no mock can prove a charge survives a concurrent upgrade webhook. Opt in via INT_TEST_DATABASE_URL (docs/integration-tests.md).
+const url = process.env.INT_TEST_DATABASE_URL ?? "";
 
 const RUN_ID = `int-upgrade-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 const ORG = `${RUN_ID}-org`;

--- a/apps/app/src/shared/ai/agent-prose.test.ts
+++ b/apps/app/src/shared/ai/agent-prose.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { readAgentProse } from "./agent-prose";
+
+describe("the prose the agent reads lives in notebook-skills/", () => {
+  it("serves the system prompt, the always-on rules and the practice contract", async () => {
+    expect(await readAgentProse("system-prompt.md")).toContain(
+      "Scibly's AI Learning Designer",
+    );
+    expect(await readAgentProse("authoring-rules.md")).toContain(
+      "Non-negotiable authoring rules",
+    );
+    expect(await readAgentProse("practice-contract.md")).toContain(
+      "window.scibly.submit(work)",
+    );
+  });
+
+  it("hands back prose with no frontmatter to strip", async () => {
+    for (const file of [
+      "system-prompt.md",
+      "authoring-rules.md",
+      "practice-contract.md",
+    ] as const) {
+      expect(await readAgentProse(file)).not.toMatch(/^---\r?\n/);
+    }
+  });
+});

--- a/apps/app/src/shared/ai/agent-prose.ts
+++ b/apps/app/src/shared/ai/agent-prose.ts
@@ -1,0 +1,18 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import "server-only";
+
+export function agentFilesRoot(): string {
+  return path.join(process.cwd(), "notebook-skills");
+}
+
+export type AgentProseFile =
+  | "system-prompt.md"
+  | "authoring-rules.md"
+  | "practice-contract.md";
+
+export async function readAgentProse(file: AgentProseFile): Promise<string> {
+  const content = await fs.readFile(path.join(agentFilesRoot(), file), "utf-8");
+  return content.trim();
+}

--- a/apps/app/src/shared/content/practice/assemble-practice-document.ts
+++ b/apps/app/src/shared/content/practice/assemble-practice-document.ts
@@ -2,11 +2,11 @@ import { isFieldCorrect } from "./grade-practice-submission";
 
 const PRACTICE_CSP = [
   "default-src 'none'",
-  "script-src 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.scibly.app",
-  "style-src 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.scibly.app",
-  "img-src data: blob: https://cdnjs.cloudflare.com https://cdn.scibly.app",
+  "script-src 'unsafe-inline' https://cdnjs.cloudflare.com",
+  "style-src 'unsafe-inline' https://cdnjs.cloudflare.com",
+  "img-src data: blob: https://cdnjs.cloudflare.com",
   "font-src data: https://cdnjs.cloudflare.com",
-  "connect-src https://cdnjs.cloudflare.com https://cdn.scibly.app",
+  "connect-src https://cdnjs.cloudflare.com",
   // Not covered by default-src: a form submit would navigate off the srcdoc document.
   "form-action 'none'",
 ].join("; ");

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -1,23 +1,17 @@
 # Integration tests
 
-Six test files prove behaviour no mocked Prisma client can witness — `ts_headline`
-fragments and `substring` paging in Postgres, row locking, guarded updates,
-concurrent callers racing for the same rate-limit slot, and an external agent's
-MCP tool call reaching real tables through the real procedures:
+`*.integration.test.ts` files prove behaviour no mocked Prisma client can witness
+— `ts_headline` fragments and `substring` paging in Postgres, row locking,
+guarded updates, concurrent callers racing for the same rate-limit slot, and an
+external agent's MCP tool call reaching real tables through the real procedures.
+They all read one variable, `INT_TEST_DATABASE_URL`, and the runner finds them by
+that suffix rather than by a list, so a new one runs by existing.
 
-| File                                                                               | Variable                            |
-| ---------------------------------------------------------------------------------- | ----------------------------------- |
-| `apps/app/src/features/notebook/sources/server/search-sources.integration.test.ts` | `SOURCES_INT_TEST_DATABASE_URL`     |
-| `apps/app/src/app/api/chat/generation-debit.integration.test.ts`                   | `ENTITLEMENT_INT_TEST_DATABASE_URL` |
-| `apps/app/src/features/organizations/server/plan-upgrade.integration.test.ts`      | `ENTITLEMENT_INT_TEST_DATABASE_URL` |
-| `packages/api/src/rate-limit.integration.test.ts`                                  | `RATE_LIMIT_INT_TEST_DATABASE_URL`  |
-| `apps/app/src/features/mcp/server/create-course.integration.test.ts`               | `MCP_INT_TEST_DATABASE_URL`         |
-| `apps/app/src/features/mcp/server/practice-scenes.integration.test.ts`             | `MCP_INT_TEST_DATABASE_URL`         |
-
-The rate-limit one lives in `packages/api`, so vitest resolves its config from
-there, not from `apps/app`. It is the only file whose subject is a race: `reserveSlot` claims
-that the _database_ decides who gets the last slot, and a fake that runs one
-statement at a time is exactly the interleaving that never disagrees.
+Most live in `apps/app`; `rate-limit.integration.test.ts` lives in `packages/api`,
+so vitest resolves its config from there and the runner covers both packages. It
+is the only file whose subject is a race: `reserveSlot` claims that the _database_
+decides who gets the last slot, and a fake that runs one statement at a time is
+exactly the interleaving that never disagrees.
 
 They are opt-in: with the variable unset the `describe` block is skipped, which is
 why `pnpm test` stays green on a machine with no database. Each file writes rows
@@ -35,10 +29,10 @@ test can reach real data.
 pnpm test:int
 ```
 
-That starts a Postgres container of its own, applies the migrations, runs all six
-files in both packages, and deletes the container on the way out — including when
-a test fails or the run is interrupted, so nothing survives to be reused by
-accident. Nothing to create beforehand; the only requirement is a running Docker.
+That starts a Postgres container of its own, applies the migrations, runs every
+integration test in both packages, and deletes the container on the way out —
+including when a test fails or the run is interrupted, so nothing survives to be
+reused by accident. Nothing to create beforehand; the only requirement is a running Docker.
 
 The image is `pgvector/pgvector:pg16`, the one `docker-compose.yml` uses: an old
 migration runs `CREATE EXTENSION "vector"` and replays on every fresh database,

--- a/packages/api/src/rate-limit.integration.test.ts
+++ b/packages/api/src/rate-limit.integration.test.ts
@@ -4,9 +4,9 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { getUtcBucketStart, withRateLimit } from "./rate-limit";
 
 // A fake DB runs one statement at a time and can't witness the race a real DB settles, so this
-// needs a live database: set RATE_LIMIT_INT_TEST_DATABASE_URL (opt-in, skipped otherwise; see
+// needs a live database: set INT_TEST_DATABASE_URL (opt-in, skipped otherwise; see
 // docs/integration-tests.md).
-const url = process.env.RATE_LIMIT_INT_TEST_DATABASE_URL ?? "";
+const url = process.env.INT_TEST_DATABASE_URL ?? "";
 
 const RUN_ID = `int-rl-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 const ENDPOINT = `${RUN_ID}-endpoint`;

--- a/scripts/int-test.sh
+++ b/scripts/int-test.sh
@@ -44,17 +44,9 @@ fi
 echo "==> schema"
 DATABASE_URL="$INT_DB" pnpm --filter @scibly/db run migrate:deploy >/dev/null
 
-echo "==> apps/app"
-SOURCES_INT_TEST_DATABASE_URL="$INT_DB" \
-ENTITLEMENT_INT_TEST_DATABASE_URL="$INT_DB" \
-MCP_INT_TEST_DATABASE_URL="$INT_DB" \
-  pnpm -C "$ROOT/apps/app" exec vitest run \
-  src/features/notebook/sources/server/search-sources.integration.test.ts \
-  src/app/api/chat/generation-debit.integration.test.ts \
-  src/features/organizations/server/plan-upgrade.integration.test.ts \
-  src/features/mcp/server/create-course.integration.test.ts \
-  src/features/mcp/server/practice-scenes.integration.test.ts
-
-echo "==> packages/api"
-RATE_LIMIT_INT_TEST_DATABASE_URL="$INT_DB" \
-  pnpm -C "$ROOT/packages/api" exec vitest run src/rate-limit.integration.test.ts
+# A substring path filter, not a filename: vitest exits non-zero if it matches nothing.
+for package in apps/app packages/api; do
+  echo "==> $package"
+  INT_TEST_DATABASE_URL="$INT_DB" \
+    pnpm -C "$ROOT/$package" exec vitest run integration.test.ts
+done


### PR DESCRIPTION
Agent-facing prose was split between `notebook-skills/` and `.ts` string literals. It now all lives in `notebook-skills/` as markdown — the system prompt, the always-on authoring rules and the practice contract — read through `readAgentProse`, with a `practice-scenes` skill so the contract is discoverable.

Also collapses the per-suite integration-test env vars into a single `INT_TEST_DATABASE_URL` and lets `int-test.sh` discover suites by path.

1273 tests pass, typecheck clean, production build traces the markdown into the `/api/mcp` and `/api/chat` bundles.